### PR TITLE
allow auth plugin, include test module

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -4,10 +4,10 @@
 uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
 
 [[BinaryProvider]]
-deps = ["Libdl", "Logging", "SHA"]
-git-tree-sha1 = "c7361ce8a2129f20b0e05a89f7070820cfed6648"
+deps = ["Libdl", "SHA"]
+git-tree-sha1 = "5b08ed6036d9d3f0ee6369410b830f8873d4024c"
 uuid = "b99e7846-7c00-51b0-8f62-c81ae34c0232"
-version = "0.5.6"
+version = "0.5.8"
 
 [[Dates]]
 deps = ["Printf"]

--- a/Project.toml
+++ b/Project.toml
@@ -12,7 +12,11 @@ HTTP = "0.8"
 julia = "1.3"
 
 [extras]
+Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
+MbedTLS = "739be429-bea8-5141-9913-cc70e7f3736d"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+Serialization = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test"]
+test = ["Base64", "MbedTLS", "Random", "Serialization", "Test"]

--- a/src/PkgServer.jl
+++ b/src/PkgServer.jl
@@ -11,9 +11,7 @@ const REGISTRIES = Dict(
         "https://github.com/JuliaRegistries/General",
 )
 const STORAGE_SERVERS = [
-    # "https://pkg.julialang.org"
-    # "http://127.0.0.1:8080",
-    # "http://127.0.0.1:8081",
+    "https://pkg.julialang.org"
 ]
 sort!(STORAGE_SERVERS)
 register_storage_server(server_url) = push!(STORAGE_SERVERS, server_url)
@@ -224,7 +222,9 @@ function serve_file(http::HTTP.Stream, path::String)
     end
 end
 
-authenticated(f, http, authmodule) = (authmodule === nothing) ? f() : authmodule.handle_authenticated(()->f(), http)
+authenticated(f, http, authmodule) =
+    (authmodule === nothing) ? f() : authmodule.handle_authenticated(()->f(), http)
+
 function start(servername, serverport; authmodule=nothing, sslconfig=nothing)
     refresh_url = "http://$servername:$serverport/auth/refresh"
     mkpath("temp")
@@ -236,7 +236,7 @@ function start(servername, serverport; authmodule=nothing, sslconfig=nothing)
             forget_failures()
             update_registries()
         end
-        @info("server listening", ssl=(sslconfig !== nothing))
+        @info("server listening", ssl=(sslconfig !== nothing), port=serverport)
         HTTP.listen(servername, serverport; sslconfig=sslconfig) do http
             found = true
             resource = http.message.target

--- a/src/PkgServer.jl
+++ b/src/PkgServer.jl
@@ -225,7 +225,7 @@ function serve_file(http::HTTP.Stream, path::String)
 end
 
 authenticated(f, http, authmodule) = (authmodule === nothing) ? f() : authmodule.handle_authenticated(()->f(), http)
-function start(servername, serverport; authmodule=nothing)
+function start(servername, serverport; authmodule=nothing, sslconfig=nothing)
     refresh_url = "http://$servername:$serverport/auth/refresh"
     mkpath("temp")
     mkpath("cache")
@@ -236,8 +236,8 @@ function start(servername, serverport; authmodule=nothing)
             forget_failures()
             update_registries()
         end
-        @info "server listening"
-        HTTP.listen(servername, serverport) do http
+        @info("server listening", ssl=(sslconfig !== nothing))
+        HTTP.listen(servername, serverport; sslconfig=sslconfig) do http
             found = true
             resource = http.message.target
             if (resource == "/auth/issue") && (authmodule !== nothing)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,8 @@
 using PkgServer
 using Test
+include("test_auth.jl")
 
 @testset "PkgServer.jl" begin
-    # Write your own tests here.
+    PkgServer.register_storage_server("https://pkg.julialang.org")
+    PkgServer.start("127.0.0.1", 8000, authmodule=TestAuth)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,8 +1,10 @@
 using PkgServer
 using Test
+using MbedTLS
 include("test_auth.jl")
 
 @testset "PkgServer.jl" begin
+    sslconfig = (isfile("cert.pem") && isfile("key.pem")) ? SSLConfig(joinpath(@__DIR__, "cert.pem"), joinpath(@__DIR__, "key.pem")) : nothing
     PkgServer.register_storage_server("https://pkg.julialang.org")
-    PkgServer.start("127.0.0.1", 8000, authmodule=TestAuth)
+    PkgServer.start("127.0.0.1", 8000; authmodule=TestAuth, sslconfig=sslconfig)
 end

--- a/test/test_auth.jl
+++ b/test/test_auth.jl
@@ -1,0 +1,106 @@
+"""
+This defines a module that can be plugged in to PkgServer as an optional authentication layer.
+
+- intended to serve as a test authentication system only.
+- reads userid and password from a plaintext file.
+- issues access_token and refresh_token after authenticating plaintext userid and password.
+- validates access_token
+- issues new access_token and refresh_token given a valid refresh_token
+"""
+module TestAuth
+
+using HTTP
+using Random
+using Pkg.TOML
+using Base64
+using Serialization
+
+const token_validity_duration = 60*60*24
+function create_access_token(userid; expires_in=token_validity_duration)
+    time_now = round(Int, time())
+    expires_at = time_now + expires_in
+    (expires_at=expires_at, expires_in=expires_in, userid=userid)
+end
+decode_access_token(access_token_hdr) = deserialize(IOBuffer(base64decode(access_token_hdr)))
+function encode_access_token(access_token)
+    iob = IOBuffer()
+    serialize(iob, access_token)
+    base64encode(take!(iob))
+end
+validate_access_token(access_token) = (access_token.expires_at >= time())
+
+const authdb = ["guest1" "password1" ""; "guest2" "password2" ""]
+
+function do_issue_token(userid, password)
+    for idx in 1:length(authdb)
+        if authdb[idx,1] == userid
+            (authdb[idx,2] == password) || error("invalid password")
+            authdb[idx,3] = refreshtok = randstring(32)
+            return create_access_token(userid), refreshtok # return access and refresh tokens
+        end
+    end
+    error("invalid userid")
+end
+
+function do_refresh_token(refreshtok)
+    for idx in 1:length(authdb)
+        if authdb[idx,3] == refreshtok
+            authdb[idx,3] = refreshtok = randstring(32)
+            return create_access_token(authdb[idx,1]), refreshtok # return access and refresh tokens
+        end
+    end
+    error("invalid refresh token")
+end
+
+function serve_token(http::HTTP.Stream, access_token, refresh_token, refresh_url)
+    TOML.print(http, Dict(
+        "access_token" => encode_access_token(access_token),
+        "refresh_token" => refresh_token,
+        "userid" => access_token.userid,
+        "expires_at" => access_token.expires_at,
+        "expires_in" => access_token.expires_in,
+        "refresh_url" => refresh_url
+    ))
+end
+
+function extract_token(http::HTTP.Stream)
+    auth_header = HTTP.header(http, "Authorization")
+    @assert startswith(auth_header, "Bearer ")
+    split(auth_header, ' '; limit=2)[2]
+end
+
+function handle_authtoken_issue(http::HTTP.Stream, refresh_url)
+    try
+        body = HTTP.URIs.queryparams(String(HTTP.read(http)))
+        access_token, refresh_token = do_issue_token(body["user_name"], body["password"])
+        serve_token(http, access_token, refresh_token, refresh_url)
+    catch
+        HTTP.setstatus(http, 401)
+        startwrite(http)
+    end
+end
+
+function handle_authtoken_refresh(http::HTTP.Stream, refresh_url)
+    try
+        token = extract_token(http)
+        access_token, refresh_token = do_refresh_token(token)
+        serve_token(http, access_token, refresh_token, refresh_url)
+    catch
+        HTTP.setstatus(http, 401)
+        startwrite(http)
+    end
+end
+
+function handle_authenticated(f, http::HTTP.Stream)
+    token = extract_token(http)
+    access_token = decode_access_token(token)
+    if validate_access_token(access_token)
+        return f()
+    else
+        HTTP.setstatus(http, 401)
+        startwrite(http)
+        true
+    end
+end
+
+end # module TestAuth


### PR DESCRIPTION
Allow authentication to be plugged in as a module.
Also added an API `register_storage_server` to register a storage server.

A file in test folder `test/test_auth.jl` defines a module that can be plugged in to PkgServer as an optional authentication layer.
- intended to serve as a test authentication system only.
- reads userid and password from a plaintext file.
- issues access_token and refresh_token after authenticating plaintext userid and password.
- validates access_token
- issues new access_token and refresh_token given a valid refresh_token