### PR TITLE
Close `IO` object before moving underlying file

### DIFF
--- a/src/PkgServer.jl
+++ b/src/PkgServer.jl
@@ -102,6 +102,7 @@ function update_registries()
             hash = REGISTRY_HASHES[uuid]
             println(io, "/registry/$uuid/$hash")
         end
+        close(io)
         mv(temp_file, joinpath("cache", "registries"), force=true)
     end
     return changed


### PR DESCRIPTION
This fixes a bug where the `registries` file can be "saved" as empty.