### PR TITLE
Add deployment example configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,7 @@
 # PkgServer
+
+Reference implementation of a Julia Pkg server, providing advanced package serving and caching capabilities.
+
+## Deployment
+
+See the [deployment](`deployment/`) directory for an example `docker-compose` setup to easily deploy your own mirror Pkg server.

--- a/bin/run_server.jl
+++ b/bin/run_server.jl
@@ -1,0 +1,11 @@
+#!/usr/bin/env julia
+
+# Accept optional environment-based arguments
+host = get(ENV, "PKGSERVER_HOST", "127.0.0.1")
+port = parse(Int, get(ENV, "PKGSERVER_PORT", "8000"))
+storage_servers = split(get(ENV, "PKGSERVER_STORAGESERVERS", "http://127.0.0.1"), ",")
+
+using PkgServer
+empty!(PkgServer.STORAGE_SERVERS)
+append!(PkgServer.STORAGE_SERVERS, storage_servers)
+PkgServer.start(;host=host, port=port)

--- a/deployment/.env.example
+++ b/deployment/.env.example
@@ -1,0 +1,7 @@
+# Example values: create a `.env` file with appropriate values for your deployment
+
+# The fully-qualified doman iname that this Pkg server will be accessible at (used by certbot)
+FQDN=pkg.julialang.org
+
+# The email that should be given to certbot as the owner of the SSL certificate
+CERTBOT_EMAIL=info@foobar.com

--- a/deployment/.gitignore
+++ b/deployment/.gitignore
@@ -1,0 +1,2 @@
+# Ignore local configuration setup
+.env

--- a/deployment/Makefile
+++ b/deployment/Makefile
@@ -1,0 +1,21 @@
+# Default to deploying with SSL
+USE_SSL = 1
+
+ifeq (1,$(USE_SSL))
+COMPOSE_FILE := docker-compose.ssl.yml
+else
+COMPOSE_FILE := docker-compose.nossl.yml
+endif
+export COMPOSE_FILE
+
+up:
+	docker-compose up --build --remove-orphans -d
+
+build:
+	docker-compose build --pull
+
+logs:
+	docker-compose logs -f --tail=100
+
+down:
+	docker-compose down --remove-orphans

--- a/deployment/Makefile
+++ b/deployment/Makefile
@@ -19,3 +19,6 @@ logs:
 
 down:
 	docker-compose down --remove-orphans
+
+destroy:
+	docker-compose down -v --remove-orphans

--- a/deployment/README.md
+++ b/deployment/README.md
@@ -1,0 +1,7 @@
+# Deployment configuration
+
+We support two deployment configurations: a non-SSL version, and an SSL version.  The non-SSL version just runs the the pkg server directly on port `80`.  The SSL version runs an `nginx` SSL terminator (hooked up with `letsencrypt`), then `proxy_pass`'es the decrypted traffic to a PkgServer instance running within a separate container.
+
+To avoid needing to memorize arcane `docker-compose` commands, a handy `Makefile` is provided to ease usage of `docker-compose`.  Valid make verbs are `up`, `build`, `logs`, `down`, etc....  By default, the SSL version will be deployed, to build/deploy the non-ssl version, invoke `make` with the `USE_SSL=0` flag.
+
+When using SSL, you must provide a `.env` file with the values `FQDN` and `CERTBOT_EMAIL` defined in order for certbot to be able to automatically get/renew SSL certificates for your SSL termination.  See the `.env.example` file for what it should look like.

--- a/deployment/docker-compose.nossl.yml
+++ b/deployment/docker-compose.nossl.yml
@@ -10,7 +10,7 @@ services:
 
         restart: unless-stopped
         ports:
-            - 80:8000
+            - 8000:8000
         environment:
             PKGSERVER_HOST: "0.0.0.0"
             PKGSERVER_PORT: "8000"

--- a/deployment/docker-compose.nossl.yml
+++ b/deployment/docker-compose.nossl.yml
@@ -1,0 +1,21 @@
+version: '2'
+services:
+    pkgserver:
+        build:
+            # We tell it the build context is `..` because we
+            # actually want to copy the parent directory in so
+            # that we can `Pkg.add()` it during the build
+            context: ..
+            dockerfile: deployment/pkgserver/Dockerfile
+
+        restart: unless-stopped
+        ports:
+            - 80:8000
+        environment:
+            PKGSERVER_HOST: "0.0.0.0"
+            PKGSERVER_PORT: "8000"
+            PKGSERVER_STORAGESERVERS: "https://pkg.julialang.org"
+        volumes:
+            - cache:/app/cache
+volumes:
+    cache:

--- a/deployment/docker-compose.ssl.yml
+++ b/deployment/docker-compose.ssl.yml
@@ -1,0 +1,35 @@
+version: '2'
+services:
+    pkgserver:
+        build:
+            # We tell it the build context is `..` because we
+            # actually want to copy the parent directory in so
+            # that we can `Pkg.add()` it during the build
+            context: ..
+            dockerfile: deployment/pkgserver/Dockerfile
+
+        restart: unless-stopped
+        expose:
+            - 8000
+        environment:
+            PKGSERVER_HOST: "0.0.0.0"
+            PKGSERVER_PORT: "8000"
+            PKGSERVER_STORAGESERVERS: "https://pkg.julialang.org"
+        volumes:
+            - cache:/app/cache
+
+    frontend:
+        build:
+            context: frontend
+            args:
+                FQDN: $FQDN
+        restart: unless-stopped
+        environment:
+            CERTBOT_EMAIL: $CERTBOT_EMAIL
+        ports:
+            - 80:80/tcp
+            - 443:443/tcp
+        depends_on:
+            - pkgserver
+volumes:
+    cache:

--- a/deployment/frontend/Dockerfile
+++ b/deployment/frontend/Dockerfile
@@ -1,0 +1,10 @@
+FROM staticfloat/nginx-certbot
+
+# Accept FQDN parameter from caller
+ARG FQDN
+
+# Copy nginx.conf to /etc/nginx/conf.d/
+ADD nginx.conf /etc/nginx/conf.d/${FQDN}.conf
+
+# Replace all instances of {FQDN} within the configuration file
+RUN sed -i "s/{FQDN}/${FQDN}/g" /etc/nginx/conf.d/${FQND}.conf

--- a/deployment/frontend/Dockerfile
+++ b/deployment/frontend/Dockerfile
@@ -7,4 +7,4 @@ ARG FQDN
 ADD nginx.conf /etc/nginx/conf.d/${FQDN}.conf
 
 # Replace all instances of {FQDN} within the configuration file
-RUN sed -i "s/{FQDN}/${FQDN}/g" /etc/nginx/conf.d/${FQND}.conf
+RUN sed -i "s/{FQDN}/${FQDN}/g" /etc/nginx/conf.d/${FQDN}.conf

--- a/deployment/frontend/nginx.conf
+++ b/deployment/frontend/nginx.conf
@@ -1,0 +1,16 @@
+server {
+    listen              443 ssl;
+    server_name         {FQDN};
+    ssl_certificate     /etc/letsencrypt/live/{FQDN}/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/{FQDN}/privkey.pem;
+
+    # Pass all traffic off to pkgserver:8000
+    location / {
+        proxy_pass http://pkgserver:8000;
+        proxy_http_version 1.1;
+        proxy_set_header Host $http_host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Real-IP $remote_addr;
+    }
+}

--- a/deployment/pkgserver/Dockerfile
+++ b/deployment/pkgserver/Dockerfile
@@ -1,0 +1,16 @@
+FROM julia:1.3
+
+# This Dockerfile must be built with a context of the top-level PkgServer.jl directory
+WORKDIR /app
+
+# Do initial update so that we at least have a registry cloned, to speed up the instantiate later
+RUN ["julia", "-e", "using Pkg; Pkg.update()"]
+
+# Copy in full `PkgServer.jl` directory
+ADD . /app
+
+# Tell Julia to instantiate our project
+RUN ["julia", "--project=/app", "-e", "using Pkg; Pkg.instantiate()"]
+
+# Our default comamnd is to run the pkg server with the bundled `run_server.jl` script
+CMD ["julia", "--project=/app", "/app/bin/run_server.jl"]

--- a/src/PkgServer.jl
+++ b/src/PkgServer.jl
@@ -238,8 +238,8 @@ function start(;host="127.0.0.1", port=8000)
             if occursin(resource_re, resource)
                 path = fetch(resource)
                 if path !== nothing
-                    setheader(http, "Content-Length" => string(filesize(path)))
-                    setheader(http, "Content-Encoding" => "gzip")
+                    HTTP.setheader(http, "Content-Length" => string(filesize(path)))
+                    HTTP.setheader(http, "Content-Encoding" => "gzip")
                     startwrite(http)
                     serve_file(http, path)
                     return


### PR DESCRIPTION
@StefanKarpinski here is my deployment example.  For reference, the `https://cn.pkg.julialang.org` server is running exactly this branch, with the following steps:  First, create an appropriate `deployment/.env` file with `FQDN=cn.pkg.julialang.org` and with an appropriate email.  Next, just run `make USE_SSL=0` (since there are other things running on this same server, and I needed to integrate into their own front-end server; if this were on a standalone host I would be able to just run `make`).

You can test this locally by running `make USE_SSL=0` (assuming you have `docker` and `docker-compose` installed; I recommend running `pip install --user docker-compose` if you don't have `docker-compose`; it's just a python package.  Note that you'll need to add `~/.local/bin` to your path to pick up those python executable scripts that `pip` installs to your user directory).  It should set up a docker container that you can connect to via `localhost:8000`.  I tested that the pkg server works by running `make USE_SSL=0 logs` in one terminal, then `JULIA_PKG_SERVER=http://localhost JULIA_DEPOT_PATH=$(pwd) julia-master -e 'using Pkg; Pkg.add("Gtk")'` in the other, and watching the Pkg server download a bevvy of artifacts, packages, and even the registry.

This deployment, by default, stores its bits in a docker volume cleverly named `cache` (since it's running inside of a folder named `deployment` the actual docker volume name should be `deployment_cache`; you can check via `docker volume ls`); if you want to inspect it, you can either `docker exec -ti <pkgserver_container_identifier> bash` to open up a `bash` shell inside of the same container that's actually running the pkgserver (you can find the id through `docker ps`) or you can launch a new container from whatever image you wish and just map that volume in to a convenient mount point with something like `docker run --rm -v deployment_cache:/cache -ti ubuntu`.  That's how I often poke around and look at what the server is actually saving.  That volume will be persistent unless you run `make destroy`, which explicitly instructs `docker-compose` to delete all volumes as well as all containers.