### PR TITLE
format storage_servers envrionment

### DIFF
--- a/bin/run_server.jl
+++ b/bin/run_server.jl
@@ -3,7 +3,7 @@
 # Accept optional environment-based arguments
 host = get(ENV, "PKGSERVER_HOST", "127.0.0.1")
 port = parse(Int, get(ENV, "PKGSERVER_PORT", "8000"))
-storage_servers = split(get(ENV, "PKGSERVER_STORAGESERVERS", "https://pkg.julialang.org"), ",")
+storage_servers = strip.(split(get(ENV, "PKGSERVER_STORAGESERVERS", "https://pkg.julialang.org"), ","))
 
 using PkgServer
 empty!(PkgServer.STORAGE_SERVERS)


### PR DESCRIPTION
The new format is more readable :P

```diff
- PKGSERVER_STORAGESERVERS = "http://mirrors.lflab.cn/julia,https://pkg.julialang.org"
+ PKGSERVER_STORAGESERVERS = "http://mirrors.lflab.cn/julia, https://pkg.julialang.org"
```