### PR TITLE
Serve resources in chunks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM julia:1.3
+FROM julia:1.4
 
 # This Dockerfile must be built with a context of the top-level PkgServer.jl directory
 WORKDIR /app


### PR DESCRIPTION
This avoids large amounts of memory consumption when serving large files
such as CUDA artifacts.  It should also reduce TTFB significantly.