### PR TITLE
Be more forgiving for when `JULIA_PKG_SERVER` is set

### DIFF
--- a/bin/run_server.jl
+++ b/bin/run_server.jl
@@ -9,7 +9,9 @@ try
     global host = m.captures[2]
     global port = parse(Int, m.captures[3])
 catch
-    error("Invalid JULIA_PKG_SERVER setting!")
+    @warn("Invalid JULIA_PKG_SERVER setting, ignoring and using default!")
+    global host = "0.0.0.0"
+    global port = 8000
 end
 
 storage_root = get(ENV, "JULIA_PKG_SERVER_STORAGE_ROOT", "/tmp/pkgserver")

--- a/deployment/Makefile
+++ b/deployment/Makefile
@@ -14,12 +14,14 @@ export COMPOSE_FILE
 UID=$(shell id -u)
 export UID
 
-up: storage logs/nginx
+up: storage logs/nginx logs/pkgserver
 	docker-compose up --build --remove-orphans -d
 
 storage:
 	mkdir -p $@
 logs/nginx:
+	mkdir -p $@
+logs/pkgserver:
 	mkdir -p $@
 
 # Do a manual build of the docker container


### PR DESCRIPTION
Sometimes, users have `JULIA_PKG_SERVER` set, and that address usually won't work while testing.  Just ignore it if it's set incorrectly.