### PR TITLE
Reduce cache miss latency

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -8,12 +8,6 @@ version = "1.0.1"
 [[Base64]]
 uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
 
-[[CodecZlib]]
-deps = ["TranscodingStreams", "Zlib_jll"]
-git-tree-sha1 = "ded953804d019afa9a3f98981d99b33e3db7b6da"
-uuid = "944b1d66-785c-5afd-91f1-9de20f533193"
-version = "0.7.0"
-
 [[Dates]]
 deps = ["Printf"]
 uuid = "ade2ca70-3891-5945-98fb-dc099432e06a"
@@ -28,6 +22,12 @@ repo-rev = "master"
 repo-url = "https://github.com/staticfloat/FilesystemDatastructures.jl"
 uuid = "89f0c457-83d8-4998-bfff-8b4a338c9833"
 version = "0.1.0"
+
+[[Gzip_jll]]
+deps = ["Libdl", "Pkg"]
+git-tree-sha1 = "906040639c56fd5671c86b7d0660f2702cab30f4"
+uuid = "be1be57a-8558-53c3-a7e5-50095f79957e"
+version = "1.10.0+0"
 
 [[HTTP]]
 deps = ["Base64", "Dates", "IniFile", "MbedTLS", "Sockets"]
@@ -132,21 +132,9 @@ version = "1.5.0"
 deps = ["Distributed", "InteractiveUtils", "Logging", "Random"]
 uuid = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
-[[TranscodingStreams]]
-deps = ["Random", "Test"]
-git-tree-sha1 = "7c53c35547de1c5b9d46a4797cf6d8253807108c"
-uuid = "3bb67fe8-82b1-5028-8e26-92a6c54297fa"
-version = "0.9.5"
-
 [[UUIDs]]
 deps = ["Random", "SHA"]
 uuid = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 
 [[Unicode]]
 uuid = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
-
-[[Zlib_jll]]
-deps = ["Libdl", "Pkg"]
-git-tree-sha1 = "a2e0d558f6031002e380a90613b199e37a8565bf"
-uuid = "83775a58-1f1d-513f-b197-d71354ab007a"
-version = "1.2.11+10"

--- a/Project.toml
+++ b/Project.toml
@@ -4,9 +4,9 @@ authors = ["Stefan Karpinski <stefan@karpinski.org>"]
 version = "0.1.0"
 
 [deps]
-CodecZlib = "944b1d66-785c-5afd-91f1-9de20f533193"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 FilesystemDatastructures = "89f0c457-83d8-4998-bfff-8b4a338c9833"
+Gzip_jll = "be1be57a-8558-53c3-a7e5-50095f79957e"
 HTTP = "cd3eb016-35fb-5094-929b-558a96fad6f3"
 JSON3 = "0f8b85d8-7281-11e9-16c2-39a750bddbf1"
 LibGit2 = "76f85450-5226-5b5a-8eaa-529ad045b433"
@@ -17,7 +17,6 @@ Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Sockets = "6462fe0b-24de-5631-8697-dd941f90decc"
 StructTypes = "856f2bd8-1eba-4b0a-8007-ebc267875bd4"
 Tar = "a4e569a6-e804-4fa4-b0f3-eef7a1d5b13e"
-TranscodingStreams = "3bb67fe8-82b1-5028-8e26-92a6c54297fa"
 
 [compat]
 HTTP = "0.8"

--- a/src/PkgServer.jl
+++ b/src/PkgServer.jl
@@ -3,6 +3,7 @@ module PkgServer
 using Pkg
 using HTTP
 using Base.Threads: Event, @spawn
+import Base: fetch
 using Random
 using LibGit2
 using FilesystemDatastructures
@@ -10,6 +11,8 @@ using JSON3, StructTypes
 using Sockets
 using Sockets: InetAddr
 using Dates
+using Tar
+using TranscodingStreams, CodecZlib
 
 include("resource.jl")
 include("meta.jl")

--- a/src/PkgServer.jl
+++ b/src/PkgServer.jl
@@ -12,7 +12,7 @@ using Sockets
 using Sockets: InetAddr
 using Dates
 using Tar
-using TranscodingStreams, CodecZlib
+using Gzip_jll
 
 include("resource.jl")
 include("meta.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,4 @@
-using PkgServer, Pkg, HTTP, JSON3
+using PkgServer, Pkg, HTTP, JSON3, Tar
 using Test
 
 # You can either perform the following setup:
@@ -15,13 +15,13 @@ end
 # If these are not set, we will attempt to auto-initiate them.
 server_process = nothing
 if isempty(get(ENV, "JULIA_PKG_SERVER", "")) || isempty(get(ENV, "JULIA_PKG_SERVER_STORAGE_ROOT", ""))
-    @info("Automatically starting local PkgServer for testing at http://127.0.0.1:8000")
     # Start a background PkgServer as a separate process
     code_dir = dirname(@__DIR__)
     temp_dir = mktempdir()
     ENV["JULIA_PKG_SERVER"] = "http://127.0.0.1:8000"
     ENV["JULIA_PKG_SERVER_STORAGE_ROOT"] = temp_dir
 
+    @info("Automatically starting local PkgServer for testing at $(ENV["JULIA_PKG_SERVER"])")
     global server_process = run(`$(Base.julia_cmd()) --project=$(code_dir) $(code_dir)/bin/run_server.jl`; wait=false)
 end
 
@@ -38,5 +38,7 @@ finally
         @info("Reaping automatically-started local PkgServer...")
         kill(server_process)
         wait(server_process)
+        @info("Outputting testing PkgServer logs:")
+        run(`cat $(temp_dir)/logs/pkgserver.log`)
     end    
 end

--- a/test/tests.jl
+++ b/test/tests.jl
@@ -41,7 +41,7 @@ end
         response = HTTP.get("$(server_url)/registry/$(registry_uuid)/$(registry_treehash)"; response_stream=tarball_io)
         close(tarball_io)
         @test response.status == 200
-        @test registry_treehash == PkgServer.tarball_git_hash(tarball_path)
+        @test registry_treehash == Tar.tree_hash(open(pipeline(`cat $(tarball_path)`, `gzip -d`), read=true))
     end
 
     # Verify that these files exist within the cache


### PR DESCRIPTION
Stream data both to disk and also into `Tar.tree_hash()` through a
decompressor.  Reduces an 8MB cold cache download from 3.5s to 2.5s when
testing locally.