### PR TITLE
Don't accept everything into `resource_re`

### DIFF
--- a/src/resource.jl
+++ b/src/resource.jl
@@ -4,7 +4,7 @@ const uuid_re = raw"[0-9a-z]{8}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{12}
 const hash_re = raw"[0-9a-f]{40}"
 const registry_re = Regex("^/registry/($uuid_re)/($hash_re)\$")
 const resource_re = Regex("""
-  | ^/registry/$uuid_re/$hash_re\$
+    ^/registry/$uuid_re/$hash_re\$
   | ^/package/$uuid_re/$hash_re\$
   | ^/artifact/$hash_re\$
 """, "x")

--- a/test/tests.jl
+++ b/test/tests.jl
@@ -54,6 +54,9 @@ end
     meta = JSON3.read(String(response.body))
     @test haskey(meta, "pkgserver_version")
     @test meta["pkgserver_version"] == PkgServer.get_pkgserver_version()
+
+    # Ensure that some random URL gets a 404
+    @test_throws HTTP.ExceptionRequest.StatusError HTTP.get("$(server_url)/docs")
 end
 
 function with_depot_path(f::Function, dp::Vector{String})


### PR DESCRIPTION
We accidentally forgot to get rid of a leading `|`, causing this regex
to accept everything that came its way.