### PR TITLE
Set `skip_empty=true` on all `Tar.tree_hash()` invocations

### DIFF
--- a/src/resource.jl
+++ b/src/resource.jl
@@ -284,7 +284,7 @@ function download(server::String, resource::String)
         gzip_proc = gzip(gz -> open(`$gz -d`, read=true, write=true))
 
         # Create async task to read in from gzip stdout and pipe it straight to `Tar.tree_hash()`
-        tar_extract_task = @async Tar.tree_hash(gzip_proc.out)
+        tar_extract_task = @async Tar.tree_hash(gzip_proc.out; skip_empty=true)
 
         # Create async task to tee chunks of data from HTTP to file and to gzip
         tee_task = @async begin

--- a/test/tests.jl
+++ b/test/tests.jl
@@ -41,7 +41,7 @@ end
         response = HTTP.get("$(server_url)/registry/$(registry_uuid)/$(registry_treehash)"; response_stream=tarball_io)
         close(tarball_io)
         @test response.status == 200
-        @test registry_treehash == Tar.tree_hash(open(pipeline(`cat $(tarball_path)`, `gzip -d`), read=true))
+        @test registry_treehash == Tar.tree_hash(open(pipeline(`cat $(tarball_path)`, `gzip -d`), read=true); skip_empty=true)
     end
 
     # Verify that these files exist within the cache


### PR DESCRIPTION
This matches default `git` behavior, which is what our hashes so far
have been created using.  Without this, URLS such as this one are being
rejected:

https://github.com/JuliaPackaging/Yggdrasil/releases/download/GCCBootstrap-v7.1.0+0/GCCBootstrap-aarch64-linux-gnu.v7.1.0.x86_64-linux-musl.unpacked.tar.gz