### PR TITLE
Add some simple stress tests

### DIFF
--- a/test/stress_tests/common.sh
+++ b/test/stress_tests/common.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+randhex()
+{
+    openssl rand -hex $1
+#    cat /dev/urandom | LC_CTYPE=C tr -dc 'a-f0-9' | fold -w $1 | head -n 1
+}
+
+randuuid()
+{
+    HEX=$(randhex 32)
+    echo -n "${HEX:0:8}-${HEX:8:4}-${HEX:12:4}-${HEX:16:4}-${HEX:20:8}"
+    #echo -n "$(randhex 8)-$(randhex 4)-$(randhex 4)-$(randhex 4)-$(randhex 12)"
+}
+
+randsha1()
+{
+    echo -n $(randhex 40)
+}
+
+server()
+{
+    echo -n "${JULIA_PKG_SERVER:-http://localhost:8000}"
+}
+
+url()
+{
+    echo -n "$(server)/${1}"
+}
+
+echo "Using server $(server) for stress tests"

--- a/test/stress_tests/stress_404.sh
+++ b/test/stress_tests/stress_404.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+source common.sh
+
+num_tests=1000
+num_procs=100
+for idx in $(seq 1 ${num_tests}); do
+    fake_uuid=$(randuuid)
+    fake_hash=$(randsha1)
+    echo "curl -w \"%{http_code} - ${idx}\\n\" -s -L -o /dev/null $(url package/$fake_uuid/$fake_hash)"
+    echo "curl -w \"%{http_code} - ${idx}\\n\" -s -L -o /dev/null $(url artifact/$fake_hash)"
+done | parallel -j${num_procs}

--- a/test/stress_tests/stress_large_artifact.sh
+++ b/test/stress_tests/stress_large_artifact.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+source common.sh
+
+true_hash=d69cdbc9a382494e9e4d7ac7093266fc9be65aa8
+
+
+num_tests=1000
+num_procs=100
+for idx in $(seq 1 $num_tests); do
+    echo "curl -w \"%{http_code} - ${idx}\\n\" -s -L -o /dev/null $(url artifact/${true_hash})"
+done | parallel -j${num_procs}

--- a/test/stress_tests/stress_small_artifact.sh
+++ b/test/stress_tests/stress_small_artifact.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+source common.sh
+
+true_hash=ade2fa0e2f7d895014746470d2cb7348d7852e2c
+
+
+num_tests=1000
+num_procs=100
+for idx in $(seq 1 $num_tests); do
+    echo "curl -w \"%{http_code} - ${idx}\\n\" -s -L -o /dev/null $(url artifact/${true_hash})"
+done | parallel -j${num_procs}
+

--- a/test/stress_tests/stress_small_package.sh
+++ b/test/stress_tests/stress_small_package.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+source common.sh
+
+true_uuid=de9282ab-8554-53be-b2d6-f6c222edabfc
+true_hash=75470c0d825076c229ec59e60bd81f83e878bbc4
+
+num_tests=1000
+num_procs=100
+for idx in $(seq 1 $num_tests); do
+    echo "curl -w \"%{http_code} - ${idx}\\n\" -s -L -o /dev/null $(url package/${true_uuid}/${true_hash})"
+done | parallel -j${num_procs}
+


### PR DESCRIPTION
In an effort to track down the memory usage issues, I have written some simple stress tests that use `curl` and GNU parallel to create nasty conditions for the server.  So far, no dice.