### PR TITLE
Move to using `$region.storage.juliahub.com` instead of `julialang.org` DNS names

### DIFF
--- a/bin/run_server.jl
+++ b/bin/run_server.jl
@@ -15,7 +15,7 @@ catch
 end
 
 storage_root = get(ENV, "JULIA_PKG_SERVER_STORAGE_ROOT", "/tmp/pkgserver")
-storage_servers = strip.(split(get(ENV, "JULIA_PKG_SERVER_STORAGE_SERVERS", "https://us-east.storage.julialang.org,https://kr.storage.julialang.org"), ","))
+storage_servers = strip.(split(get(ENV, "JULIA_PKG_SERVER_STORAGE_SERVERS", "https://us-east.storage.juliahub.com,https://kr.storage.juliahub.com"), ","))
 log_dir = get(ENV, "JULIA_PKG_SERVER_LOGS_DIR", joinpath(storage_root, "logs"))
 
 mkpath(storage_root)

--- a/deployment/docker-compose.nossl.yml
+++ b/deployment/docker-compose.nossl.yml
@@ -12,7 +12,7 @@ services:
         environment:
             JULIA_PKG_SERVER: "0.0.0.0:8000"
             JULIA_PKG_SERVER_FQDN: "$FQDN"
-            JULIA_PKG_SERVER_STORAGE_SERVERS: "https://us-east.storage.julialang.org,https://kr.storage.julialang.org"
+            JULIA_PKG_SERVER_STORAGE_SERVERS: "https://us-east.storage.juliahub.com,https://kr.storage.juliahub.com"
             JULIA_PKG_SERVER_STORAGE_ROOT: "/app/storage"
             JULIA_PKG_SERVER_LOGS_DIR: "/app/logs"
         labels:

--- a/deployment/docker-compose.ssl.yml
+++ b/deployment/docker-compose.ssl.yml
@@ -12,7 +12,7 @@ services:
         environment:
             JULIA_PKG_SERVER: "0.0.0.0:8000"
             JULIA_PKG_SERVER_FQDN: "$FQDN"
-            JULIA_PKG_SERVER_STORAGE_SERVERS: "https://us-east.storage.julialang.org,https://kr.storage.julialang.org"
+            JULIA_PKG_SERVER_STORAGE_SERVERS: "https://us-east.storage.juliahub.com,https://kr.storage.juliahub.com"
             JULIA_PKG_SERVER_STORAGE_ROOT: "/app/storage"
             JULIA_PKG_SERVER_LOGS_DIR: "/app/logs"
         labels:

--- a/src/PkgServer.jl
+++ b/src/PkgServer.jl
@@ -43,8 +43,8 @@ struct ServerConfig
                                 RegistryMeta("https://github.com/JuliaRegistries/General")
                             ),
                             storage_servers = [
-                                "https://us-east.storage.julialang.org",
-                                "https://kr.storage.julialang.org",
+                                "https://us-east.storage.juliahub.com",
+                                "https://kr.storage.juliahub.com",
                             ],
                             keep_free=3*1024^3)
         # Right now, the only thing we store in `static/` is `/registries`


### PR DESCRIPTION
This makes the JC-owned nature of these more clear.

@fredrikekre can you update StatPing to pull from these new names instead of the old `$region.storage.julialang.org` names?  It's redirecting for now, but it won't forever.