### PR TITLE
Stop `watchtower` when running tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ before_script:
     - if [ ${USE_DOCKER} = 1 ]; then
         docker build -t juliapackaging/pkgserver.jl .;
         make -C deployment up;
+        make -C deployment stop-watchtower;
         (make -C deployment logs &);
         export JULIA_PKG_SERVER="http://localhost:8000";
         export JULIA_PKG_SERVER_STORAGE_ROOT=$(pwd)/deployment/storage;

--- a/deployment/Makefile
+++ b/deployment/Makefile
@@ -17,6 +17,9 @@ export UID
 up: storage logs/nginx logs/pkgserver
 	docker-compose up --build --remove-orphans -d
 
+stop-watchtower:
+	docker-compose stop watchtower
+
 storage:
 	mkdir -p $@
 logs/nginx:


### PR DESCRIPTION
Sometimes, when running Travis on a newly-merged commit, Docker Hub gets
through with a new image faster than our test suite can finish, and
watchtower updates our image, causing the test suite to fail.  Let's
just not use watchtower at all when we're doing tests.