### PR TITLE
If we are serving a `HEAD` request, don't write out any content

### DIFF
--- a/src/meta.jl
+++ b/src/meta.jl
@@ -122,7 +122,9 @@ function serve_json(http::HTTP.Stream, data)
     json = JSON3.write(data)
     HTTP.setheader(http, "Content-Length" => string(length(json)))
     HTTP.setheader(http, "Content-Type" => "application/json")
-    startwrite(http)
+    if http.message.method == "GET"
+        startwrite(http)
+    end
     return write(http, json)
 end
 

--- a/src/resource.jl
+++ b/src/resource.jl
@@ -429,18 +429,20 @@ function serve_file(
     # Account this hit
     global total_hits += 1
 
-    # Open the path, write it out directly to the HTTP stream in chunks
-    open(path) do io
-        seek(io, startbyte)
-        t = 0
-        while t < content_length
-            # See JuliaLang/julia#36300, can be optimized later to only read r bytes
-            # r = min(length(buffer), content_length - t)
-            n = readbytes!(io, buffer, #=r=#)
-            t += write(http, view(buffer, 1:min(n, content_length - t)))
-        end
-        if t != content_length
-            @error "file size mismatch" path stat_size=content_length actual=t
+    if http.message.method == "GET"
+        # Open the path, write it out directly to the HTTP stream in chunks
+        open(path) do io
+            seek(io, startbyte)
+            t = 0
+            while t < content_length
+                # See JuliaLang/julia#36300, can be optimized later to only read r bytes
+                # r = min(length(buffer), content_length - t)
+                n = readbytes!(io, buffer, #=r=#)
+                t += write(http, view(buffer, 1:min(n, content_length - t)))
+            end
+            if t != content_length
+                @error "file size mismatch" path stat_size=content_length actual=t
+            end
         end
     end
 end


### PR DESCRIPTION
This fixes https://github.com/JuliaWeb/HTTP.jl/issues/559, although it
is a little strange that one request could effect another.