### PR TITLE
Stream in-progress downloads back to the client

### DIFF
--- a/src/meta.jl
+++ b/src/meta.jl
@@ -153,10 +153,18 @@ function serve_meta_stats(http::HTTP.Stream)
         "lru" => config.cache.entries,
         "packages_cached" => get_num_pkgs_cached(),
         "artifacts_cached" => get_num_artifacts_cached(),
-        # Global response statistics
+
+        ## Global response statistics:
+        # Number of requests we've had total.  Should equal `cached_hits + fetch_hits`.
         "total_hits" => total_hits,
+        # Number of requests served through the happy path; file was already present on disk.
         "cached_hits" => cached_hits,
+        # Number of requests that were served by fetching it from the server.
+        # Note; if three simultaneous requests come in for a file that we need to fetch,
+        # we'll only fetch it once, but we'll stream the content back for all three, and
+        # account all three as a `fetch_hit`.
         "fetch_hits" => fetch_hits,
+        # Number of requests that could not be served
         "total_misses" => total_misses,
         "payload_bytes_received" => payload_bytes_received,
         "payload_bytes_transmitted" => payload_bytes_transmitted,

--- a/src/task_utils.jl
+++ b/src/task_utils.jl
@@ -14,3 +14,60 @@ macro try_printerror(ex)
         end
     end
 end
+
+"""
+    tee_task(io_in, io_outs...)
+
+Creates an asynchronous task that reads in from `io_in` in buffer chunks, writing
+available bytes out to all elements of `io_outs` as quickly as possible until `io_in` is
+closed.  Closes all elements of `io_outs` once that is finished.  Returns the `Task`.
+"""
+function tee_task(io_in, io_outs...)
+    return @async begin
+        @try_printerror begin
+            total_size = 0
+            while !eof(io_in)
+                chunk = readavailable(io_in)
+                total_size += length(chunk)
+                for io_out in io_outs
+                    write(io_out, chunk)
+                end
+            end
+            for io_out in io_outs
+                close(io_out)
+            end
+            return total_size
+        end
+    end
+end
+
+"""
+    wait_first(args...)
+
+Return the first waitable (Task, Condition, etc...) that becomes ready.
+"""
+function wait_first(args...)
+    if isempty(args)
+        return nothing
+    end
+
+    c = Channel()
+    for arg in args
+        @async begin
+            wait(arg)
+            put!(c, arg)
+        end
+    end
+    return take!(c)
+end
+
+function try_open(args...; kwargs...)
+    try
+        return open(args...; kwargs...)
+    catch e
+        if isa(e, InterruptException)
+            rethrow(e)
+        end
+    end
+    return nothing
+end

--- a/test/tests.jl
+++ b/test/tests.jl
@@ -156,7 +156,8 @@ end
     figlet_fonts_entry = stats["lru"][figlet_fonts_resource]
     @test figlet_fonts_entry["num_accessed"] > 0
 
-    # Now, hit this a couple more times:
+    # Now, hit this a couple more times.  We'll hit it a few more times now, while it's still streaming,
+    # to trigger the streaming codepaths
     for idx in 1:5
         HTTP.get("$(server_url)/$(figlet_fonts_resource)")
     end
@@ -204,6 +205,7 @@ end
     uuid = "7876af07-990d-54b4-ab0e-23690620f79a"
     treehash = "46e44e869b4d90b96bd8ed1fdcf32244fddfb6cc"
     content_url = "$(server_url)/package/$uuid/$treehash"
+    cache_path = joinpath(cache_dir, "package", uuid, treehash)
     # Get full file
     full_resp = HTTP.get(content_url)
     @test full_resp.status == 200
@@ -239,4 +241,12 @@ end
     @test HTTP.header(partial_resp, "Content-Range") == ""
     @test HTTP.header(partial_resp, "Content-Length") == string(full_length)
     @test partial_resp.body == full_resp.body
+
+    # Specifying both startbyte and stopbyte but streaming rather than cached
+    rm(cache_path; force=true)
+    partial_resp = HTTP.get(content_url, ["Range"=>"bytes=0-1023"]);
+    @test partial_resp.status == 206
+    @test HTTP.header(partial_resp, "Content-Range") == "bytes 0-1023/$(full_length)"
+    @test HTTP.header(partial_resp, "Content-Length") == "1024"
+    @test partial_resp.body == full_resp.body[1:1024]
 end


### PR DESCRIPTION
Rather than sit and wait for cache misses to make their way from the
StorageServer into the local cache, then start transmitting to the
client, we instead start streaming immediately to the client, before
verification is finished.  This is because we (a) generally trust the
StorageServer to not serve bad data, and (b) will immediately break off
the transmission if the validation fails.  This, coupled with the fact
that the Pkg client should also be verifying allows us to drastically
reduce cold cache latency for large artifacts.