### PR TITLE
Stream files to the user faster

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -47,9 +47,9 @@ uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 
 [[JSON3]]
 deps = ["Dates", "Mmap", "Parsers", "StructTypes", "UUIDs"]
-git-tree-sha1 = "44c9e48f096015a75386d52cfa83b8607edff257"
+git-tree-sha1 = "18a1a1bcd1070f8e2ef4c5562b7cf74cd1c2607c"
 uuid = "0f8b85d8-7281-11e9-16c2-39a750bddbf1"
-version = "1.1.1"
+version = "1.1.2"
 
 [[LibGit2]]
 deps = ["Printf"]
@@ -79,9 +79,9 @@ version = "1.0.2"
 
 [[MbedTLS_jll]]
 deps = ["Libdl", "Pkg"]
-git-tree-sha1 = "a0cb0d489819fa7ea5f9fa84c7e7eba19d8073af"
+git-tree-sha1 = "c0b1286883cac4e2b617539de41111e0776d02e8"
 uuid = "c8ffd9c3-330d-5841-b78e-0817d7145fa1"
-version = "2.16.6+1"
+version = "2.16.8+0"
 
 [[Mmap]]
 uuid = "a63ad114-7e13-5084-954f-fe012c677804"

--- a/bin/run_server.jl
+++ b/bin/run_server.jl
@@ -9,7 +9,7 @@ try
     global host = m.captures[2]
     global port = parse(Int, m.captures[3])
 catch
-    @warn("Invalid JULIA_PKG_SERVER setting, ignoring and using default!")
+    @warn("Invalid JULIA_PKG_SERVER setting, ignoring and using default of 0.0.0.0:8000!")
     global host = "0.0.0.0"
     global port = 8000
 end

--- a/src/resource.jl
+++ b/src/resource.jl
@@ -355,31 +355,6 @@ function forget_failures()
     end
 end
 
-"""
-    tee_task(io_in, io_outs...)
-
-Creates an asynchronous task that reads in from `io_in` in buffer chunks, writing
-available bytes out to all elements of `io_outs` as quickly as possible until `io_in` is
-closed.  Closes all elements of `io_outs` once that is finished.  Returns the `Task`.
-"""
-function tee_task(io_in, io_outs...)
-    return @async begin
-        @try_printerror begin
-            total_size = 0
-            while !eof(io_in)
-                chunk = readavailable(io_in)
-                total_size += length(chunk)
-                for io_out in io_outs
-                    write(io_out, chunk)
-                end
-            end
-            for io_out in io_outs
-                close(io_out)
-            end
-            return total_size
-        end
-    end
-end
 
 """
     stream_file(io_in::IO, start_byte::Int, length::Int, dl_task::Task, io_out::IO)

--- a/test/tests.jl
+++ b/test/tests.jl
@@ -107,6 +107,25 @@ end
         end
     end
 
+    # Sleep until there's nothing left in the `temp` directory.
+    t_start = time()
+    function any_inprogress_files(temp_dir)
+        for (root, dirs, files) in walkdir(temp_dir)
+            for f in files
+                if endswith(f, ".inprogress")
+                    return true
+                end
+            end
+        end
+        return false
+    end
+    while any_inprogress_files(joinpath(cache_dir, "..", "temp"))
+        sleep(0.1)
+        if time() - t_start >= 10
+            error("Timed out waiting for temp directory to finish")
+        end
+    end
+
     # Test that the resources we expect to exist are in fact cached on the server.
     # We just test that a few UUIDs and tree hashes exist.  Note we use the exact packages
     # listed above, otherwise we may not know what the treehash actually should be.


### PR DESCRIPTION
This commit changes the flow of a cache miss to hit the disk first, then
read back from the disk for both the treehash verification branch and
the stream-unverified-files-to-the-client branch.  This removes one
`tee_task` that would otherwise have linked the speed of tree hash
verification to the speed of serving, as that `tee_task` would start to
block as one of its outputs (the treehash verification consumer) would
begin to get backed up, and fill the `BufferStream`'s entire buffer.  So
instead, we write out to disk first, allowing users to stream off of
disk as fast as `HTTP.get()` can write into that file, essentially using
the disk as an unlimited-size `BufferStream`.  This is mostly just a net
win, although there is a small downside in that if we are getting a bad
resource, we still won't know until we get to the end of verification,
and we may have successfully served the file to many clients in the
meantime.  This is an acceptable downside, as the clients should be
doing their own verification as well.