### PR TITLE
Add registry update watchdog

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
           make -C deployment up
           make -C deployment stop-watchtower
           (make -C deployment logs &)
-          echo "JULIA_PKG_SERVER=http://localhost:8000" >> ${GITHUB_ENV}
+          echo "JULIA_PKG_SERVER=http://127.0.0.1:8000" >> ${GITHUB_ENV}
           echo "JULIA_PKG_SERVER_STORAGE_ROOT=$(pwd)/deployment/storage" >> ${GITHUB_ENV}
       - uses: julia-actions/julia-buildpkg@latest
       - uses: julia-actions/julia-runtest@latest

--- a/src/meta.jl
+++ b/src/meta.jl
@@ -166,16 +166,17 @@ end
 
 function serve_meta(http::HTTP.Stream)
     # We serve a JSON representation of some metadata about this PkgServer
-    task_state = istaskfailed(registry_task) ? "failed" :
-                 istaskdone(registry_task) ? "done" :
-                 istaskstarted(registry_task) ? "started" : "not-started"
+    task_state(t) = istaskfailed(t) ? "failed" :
+                    istaskdone(t) ? "done" :
+                    istaskstarted(t) ? "started" : "not-started"
     metadata = Dict(
         "pkgserver_version" => get_pkgserver_version(),
         "pkgserver_url" => get_pkgserver_url(),
         "julia_version" => string(VERSION),
         "start_time" => string(time_start),
         "last_registry_update" => string(last_registry_update),
-        "registry_update_task" => task_state,
+        "registry_update_task" => task_state(registry_update_task),
+        "registry_watchdog_task" => task_state(registry_watchdog_task),
         "maxrss" => Int(Sys.maxrss()),
     )
     live_tasks = get_num_live_tasks()


### PR DESCRIPTION
It appears there are still cases where the registry update thread can
freeze.  We observed several servers within the last week getting
"stuck", where the update task was still alive, there were no errors in
the logs, however they were stuck for over a week.

This may be a deficiency in the downloading code, or even a logic error
somewhere else in the program.  We are adding here a registry update
watchdog that kills the entire server in the event that the registry
update loop does not run for 20 minutes.  This could probably be reduced
significantly, but in the event that things go horribly wrong, we don't
want to be rebooting the server constantly.