### PR TITLE
Ignore `test/perf` directory for Linguist

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+test/perf/* linguist-detectable=false


### PR DESCRIPTION
This should (hopefully) promote Julia to the first place in the language
breakdown on GitHub.