### PR TITLE
Ignore also files in `test/perf/data/` for linguist

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 test/perf/* linguist-detectable=false
+test/perf/data/* linguist-detectable=false


### PR DESCRIPTION
It turns out this `.gitattributes` doesn't apply the attributes recursively.
With this branch I finally get:

``` console
% github-linguist --breakdown
93.57%  Julia
3.61%   Makefile
1.62%   Dockerfile
0.69%   Shell
0.50%   HTML

Dockerfile:
Dockerfile

Julia:
bin/gen_static.jl
bin/run_server.jl
src/PkgServer.jl
src/dynamic.jl
src/meta.jl
src/resource.jl
src/task_utils.jl
test/debugging/registry_lag.jl
test/runtests.jl
test/tests.jl

Shell:
deployment/.env.example

Makefile:
deployment/Makefile

HTML:
static/index.html
```