### PR TITLE
Add `request_id` to simplify matching requests

### DIFF
--- a/deployment/Makefile
+++ b/deployment/Makefile
@@ -108,6 +108,11 @@ destroy:
 	docker-compose down -v --remove-orphans
 	rm -rf logs storage build
 
+restart:
+	$(MAKE) down
+	rm -rf build
+	$(MAKE)
+
 clean:
 	rm -rf logs build
 

--- a/deployment/conf/pkgserver.nginx.conf
+++ b/deployment/conf/pkgserver.nginx.conf
@@ -1,5 +1,5 @@
 # Setup logging to include request time and bytes sent, 
-log_format pkgserver_logformat '$remote_addr [$time_local] "$request" $status $body_bytes_sent "$http_user_agent" $request_time $http_julia_version $http_julia_system "$http_julia_ci_variables" $http_julia_interactive "$http_julia_pkg_server"';
+log_format pkgserver_logformat '$remote_addr [$time_local] "$request" $status $body_bytes_sent "$http_user_agent" $request_time $http_julia_version $http_julia_system "$http_julia_ci_variables" $http_julia_interactive "$http_julia_pkg_server" "$http_x_request_id"';
 
 # Sometimes we're running as a bare PkgServer, sometimes we're running behind a load-balancer.
 # In order to properly store logs, let's accept an `X-Real-IP` header.
@@ -45,6 +45,7 @@ ${LISTEN_BLOCK}
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
         proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Request-ID $http_x_request_id;
     }
 
     # We provide an S3 mirror for each bucket defined in S3_MIRROR_BUCKET_LIST

--- a/loadbalancer/Makefile
+++ b/loadbalancer/Makefile
@@ -58,6 +58,11 @@ destroy:
 	docker-compose down -v --remove-orphans
 	rm -rf logs build
 
+restart:
+	$(MAKE) down
+	rm -rf build
+	$(MAKE)
+
 clean:
 	rm -rf logs build
 

--- a/loadbalancer/conf/loadbalancer.nginx.conf
+++ b/loadbalancer/conf/loadbalancer.nginx.conf
@@ -1,5 +1,5 @@
 # Setup logging to include request time and bytes sent, 
-log_format pkgserver_logformat '$remote_addr [$time_local] "$request" $status $body_bytes_sent "$http_user_agent" $request_time $http_julia_version $http_julia_system "$http_julia_ci_variables" $http_julia_interactive "$http_julia_pkg_server"';
+log_format pkgserver_logformat '$remote_addr [$time_local] "$request" $status $body_bytes_sent "$http_user_agent" $request_time $http_julia_version $http_julia_system "$http_julia_ci_variables" $http_julia_interactive "$http_julia_pkg_server" "$request_id"';
 
 # This upstream uses `$request_uri` hashing to ensure that the same resource request goes to the same server
 # this allows us to essentially shard the space of resources across servers
@@ -20,24 +20,22 @@ server {
     ssl_certificate     /etc/letsencrypt/live/${FQDN}/fullchain.pem;
     ssl_certificate_key /etc/letsencrypt/live/${FQDN}/privkey.pem;
     
-
-    # In general, let's ask a different upstream if the one we're talking to errors out.
-    proxy_next_upstream error timeout;
-
     # We pass all content-addressed URLs off to consistent PkgServer locations,
     # so that each package server only needs to keep track of a portion of these resources
     location ~ /(registry|package|artifact|mirror)/ {
+        proxy_next_upstream error timeout;
         set $upstream pkgservers_hashed;
         try_files $uri @loadbalance;
     }
 
     # Everything else (`/registries`, `/meta`, etc...) gets round-robined
     location / {
+        proxy_next_upstream error timeout;
         set $upstream pkgservers_roundrobin;
         try_files $uri @loadbalance;
     }
 
-    # Everything else gets round-robined
+    # This is a trick to set common options to multiple `location` blocks.
     location @loadbalance {
         proxy_pass https://$upstream;
         proxy_http_version 1.1;
@@ -45,6 +43,7 @@ server {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
         proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Request-ID $request_id;
 
         # Report to the requester which load balancing strategy we're using (e.g. round-robin or hashed)
         add_header X-lb-strategy $upstream;


### PR DESCRIPTION
We now have a moderately complex flow for requests, where a request may bounce from loadbalancer (nginx) -> pkgserver (nginx) -> pkgserver (julia), and tracing that through based purely on timestamps can be difficult.

This adds a random ID (generated by the `nginx` loadbalancer) to each request, which is added as an HTTP header to the traffic between loadbalancer and pkgserver, and is passed along to the Julia pkgserver, so that we can trace a request the entire way through.  The ID is completely random, and is generated anew for each and every HTTP request.