### PR TITLE
add `/meta/children` to loadbalancers

### DIFF
--- a/loadbalancer/Makefile
+++ b/loadbalancer/Makefile
@@ -1,6 +1,10 @@
 # Default target is to bring everything up
 all: up
 
+# Makefile hacks
+COMMA:=,
+SPACE:=$(eval) $(eval)
+
 # Extract configuration from `.env` file
 SERVER_REGION := $(shell bash -c "source .env 2>/dev/null && echo \$$SERVER_REGION")
 PKGSERVERS := $(shell bash -c "source .env 2>/dev/null && echo \$$PKGSERVERS")
@@ -15,11 +19,18 @@ DIRS := logs/nginx build
 $(DIRS):
 	mkdir -p $@
 
+# Generate the loadbalancer configuration
 build/loadbalancer.nginx.conf: conf/loadbalancer.nginx.conf .env | build
 	@export REGION=$(SERVER_REGION); \
 	export FQDN=$${REGION}.pkg.julialang.org; \
 	export PKGSERVERS_SERVER_BLOCK="$$(printf "    server pkgserver-%s.ipv6.cflo.at:443;\n" $(PKGSERVERS))"; \
 	envsubst '$${FQDN} $${REGION} $${PKGSERVERS_SERVER_BLOCK}' < $< > $@
+up: build/loadbalancer.nginx.conf
+
+# Generate static list of child servers we hide behind our broad, load-balancing shoulders
+build/children.json: .env | build
+	@echo "[ $(subst $(SPACE),$(COMMA) ,$(patsubst %,\"%\",$(PKGSERVERS))) ]" > $@
+up: build/children.json
 
 up: $(DIRS) build/loadbalancer.nginx.conf
 	docker-compose up --build --remove-orphans -d

--- a/loadbalancer/conf/loadbalancer.nginx.conf
+++ b/loadbalancer/conf/loadbalancer.nginx.conf
@@ -35,6 +35,12 @@ server {
         try_files $uri @loadbalance;
     }
 
+    # Add special "/meta/children" endpoint that surfaces how many child servers there are
+    location =/meta/children {
+        alias /etc/nginx/children.json;
+        add_header Content-Type "application/json";
+    }
+
     # This is a trick to set common options to multiple `location` blocks.
     location @loadbalance {
         proxy_pass https://$upstream;

--- a/loadbalancer/docker-compose.yml
+++ b/loadbalancer/docker-compose.yml
@@ -12,6 +12,7 @@ services:
             # Mount in our nginx configs
             - ./build/loadbalancer.nginx.conf:/etc/nginx/user_conf.d/loadbalancer-${SERVER_FQDN:-default}.conf
             - ../deployment/conf/optimized.nginx.conf:/etc/nginx/nginx.conf
+            - ./build/children.json:/etc/nginx/children.json
             # Keep SSL certificates permanently
             - letsencrypt:/etc/letsencrypt
             # Store logs for us to peruse at our leisure

--- a/src/PkgServer.jl
+++ b/src/PkgServer.jl
@@ -151,6 +151,12 @@ function start(;kwargs...)
                 serve_siblings(http)
                 return
             end
+            if resource == "/meta/children"
+                # PkgServers don't have children, but to be good neighbors,
+                # we return an empty list here, to make it easier to recurse.
+                serve_children(http)
+                return
+            end
             if resource == "/meta/parents"
                 serve_parents(http)
                 return

--- a/src/meta.jl
+++ b/src/meta.jl
@@ -226,6 +226,10 @@ function serve_siblings(http::HTTP.Stream)
     return serve_json(http, get_pkgserver_siblings())
 end
 
+function serve_children(http::HTTP.Stream)
+    return serve_json(http, String[])
+end
+
 function serve_parents(http::HTTP.Stream)
     return serve_json(http, config.storage_servers)
 end


### PR DESCRIPTION
This allows one to programmatically enumerate all pkgservers, even those hiding behind loadbalancers.