### PR TITLE
Add `X-Cache-Miss` header

### DIFF
--- a/deployment/conf/pkgserver.nginx.conf
+++ b/deployment/conf/pkgserver.nginx.conf
@@ -1,5 +1,5 @@
 # Setup logging to include request time and bytes sent, 
-log_format pkgserver_logformat '$remote_addr [$time_local] "$request" $status $body_bytes_sent "$http_user_agent" $request_time $http_julia_version $http_julia_system "$http_julia_ci_variables" $http_julia_interactive "$http_julia_pkg_server" "$http_x_request_id"';
+log_format pkgserver_logformat '$remote_addr [$time_local] "$request" $status $body_bytes_sent "$http_user_agent" $request_time $http_julia_version $http_julia_system "$http_julia_ci_variables" $http_julia_interactive "$http_julia_pkg_server" "$http_x_request_id" "$upstream_http_x_cache_miss"';
 
 # Sometimes we're running as a bare PkgServer, sometimes we're running behind a load-balancer.
 # In order to properly store logs, let's accept an `X-Real-IP` header.

--- a/loadbalancer/conf/loadbalancer.nginx.conf
+++ b/loadbalancer/conf/loadbalancer.nginx.conf
@@ -1,5 +1,5 @@
 # Setup logging to include request time and bytes sent, 
-log_format pkgserver_logformat '$remote_addr [$time_local] "$request" $status $body_bytes_sent "$http_user_agent" $request_time $http_julia_version $http_julia_system "$http_julia_ci_variables" $http_julia_interactive "$http_julia_pkg_server" "$request_id"';
+log_format pkgserver_logformat '$remote_addr [$time_local] "$request" $status $body_bytes_sent "$http_user_agent" $request_time $http_julia_version $http_julia_system "$http_julia_ci_variables" $http_julia_interactive "$http_julia_pkg_server" "$request_id" "$upstream_http_x_cache_miss"';
 
 # This upstream uses `$request_uri` hashing to ensure that the same resource request goes to the same server
 # this allows us to essentially shard the space of resources across servers

--- a/src/PkgServer.jl
+++ b/src/PkgServer.jl
@@ -190,6 +190,7 @@ function start(;kwargs...)
                 # a `DownloadState` that represents a partial download.
                 dl_state = fetch_resource(resource, request_id)
                 if dl_state !== nothing
+                    HTTP.setheader(http, "X-Cache-Miss" => "miss")
                     stream_path = temp_resource_filepath(resource)
                     # Wait until `stream_path` is created
                     while !isfile(stream_path) && dl_state.dl_task.state != :done


### PR DESCRIPTION
This denotes when a request was a cache miss (e.g. the Julia code had to
go and download a resource)