### PR TITLE
Keep some connections open between the loadbalancer and pkgserver

### DIFF
--- a/loadbalancer/conf/loadbalancer.nginx.conf
+++ b/loadbalancer/conf/loadbalancer.nginx.conf
@@ -6,11 +6,17 @@ log_format pkgserver_logformat '$remote_addr [$time_local] "$request" $status $b
 upstream pkgservers_hashed {
     hash $request_uri consistent;
 ${PKGSERVERS_SERVER_BLOCK}
+
+    # keep at least 16 connections open at all times, to reduce the amount of
+    # handshaking we do to our upstream nginx instances.
+    keepalive 16;
 }
 
 # This upstream uses round-robin request handling
 upstream pkgservers_roundrobin {
 ${PKGSERVERS_SERVER_BLOCK}
+
+    keepalive 16;
 }
 
 server {
@@ -45,6 +51,7 @@ server {
     location @loadbalance {
         proxy_pass https://$upstream;
         proxy_http_version 1.1;
+        proxy_set_header Connection "";
         proxy_set_header Host $http_host;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;


### PR DESCRIPTION
This should reduce latency and cut down on HTTPS overhead.  In
experiments using `ab -n 10000 -c 100`, this caused an average decrease
of 10% in request time and a 2x improvement in 99% request time.