### PR TITLE
Allow the user to disable internal DNS names

### DIFF
--- a/deployment/.env.example
+++ b/deployment/.env.example
@@ -15,3 +15,6 @@ STORAGE_SERVERS=https://us-east.storage.juliahub.com,https://kr.storage.juliahub
 # Disable TLS (don't try to use certbot to get HTTPS certificates)
 # To enable TLS just comment this line out.
 DISABLE_TLS=1
+
+# Disable internal DNS names (e.g. the `pkgserver-${region}.cflo.at` ones)
+DISABLE_INTERNAL_DNS=1

--- a/deployment/Makefile
+++ b/deployment/Makefile
@@ -15,14 +15,24 @@ endif
 export PKG_SERVER_FQDN
 S3_MIRROR_BUCKET_LIST := $(shell bash -c "source .env 2>/dev/null && echo \$$S3_MIRROR_BUCKET_LIST")
 DISABLE_TLS := $(shell bash -c "source .env 2>/dev/null && echo \$$DISABLE_TLS")
-DISABLE_IPV6 := $(shell bash -c "source .env 2>/dev/null && echo \$$DISABLE_IPV6")
+DISABLE_INTERNAL_DNS := $(shell bash -c "source .env 2>/dev/null && echo \$$DISABLE_INTERNAL_DNS")
+DISABLE_INTERNAL_DNS_IPV6 := $(shell bash -c "source .env 2>/dev/null && echo \$$DISABLE_INTERNAL_DNS_IPV6")
 
 # If `DISABLE_TLS` is defined, use the `http` stanza instead of the `tls` one.
 LISTEN_SRC := $(if $(DISABLE_TLS),conf/stanza_http.conf,conf/stanza_tls.conf)
 MIRROR_SRC := conf/s3mirror.nginx.conf
 
-# If `DISABLE_IPV6` is defined, don't add the `ipv6` servername
-SERVERNAMES := $(PKG_SERVER_FQDN) pkgserver-$(PKG_SERVER_REGION).ip.cflo.at pkgserver-$(PKG_SERVER_REGION).ipv4.cflo.at $(if $(DISABLE_IPV6),,pkgserver-$(PKG_SERVER_REGION).ipv6.cflo.at)
+
+SERVERNAMES := $(PKG_SERVER_FQDN)
+# Allow the user to disable automatic certificate fetching for internal DNS names
+# This is important for the loadbalancer, but not for a naked PkgServer.
+ifneq ($(DISABLE_INTERNAL_DNS),1)
+SERVERNAMES += pkgserver-$(PKG_SERVER_REGION).ip.cflo.at
+SERVERNAMES += pkgserver-$(PKG_SERVER_REGION).ipv4.cflo.at
+ifneq ($(DISABLE_INTERNAL_DNS_IPV6),1)
+SERVERNAMES += pkgserver-$(PKG_SERVER_REGION).ipv6.cflo.at
+endif
+endif
 
 # We want to launch/build docker containers as our own UID, so we collect that from the environment
 UID=$(shell id -u)

--- a/deployment/docker-compose.yml
+++ b/deployment/docker-compose.yml
@@ -26,7 +26,7 @@ services:
             interval: 2m
             timeout: 10s
             retries: 3
-            start_period: 1m
+            start_period: 5m
     
     frontend:
         image: jonasal/nginx-certbot


### PR DESCRIPTION
We use these for datacenter-local communication between loadbalancer and
PkgServer, but for the average user, they're troublesome, so allow them
to be disabled.

The Chinese servers don't like to respond to anything other than their
registered DNS name, so disable this on them for now.