### PR TITLE
Teach PkgServer to serve multiple registry flavors

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -18,9 +18,9 @@ deps = ["ArgTools", "LibCURL", "NetworkOptions"]
 uuid = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
 
 [[FilesystemDatastructures]]
-git-tree-sha1 = "0e04af52770a492086acddc484401ff0e1dd1455"
+git-tree-sha1 = "22983924e485b0c5278467304e45c7bb01f2ac41"
 uuid = "89f0c457-83d8-4998-bfff-8b4a338c9833"
-version = "1.0.0"
+version = "1.1.0"
 
 [[Gzip_jll]]
 deps = ["Libdl", "Pkg"]
@@ -30,9 +30,9 @@ version = "1.10.0+0"
 
 [[HTTP]]
 deps = ["Base64", "Dates", "IniFile", "Logging", "MbedTLS", "NetworkOptions", "Sockets", "URIs"]
-git-tree-sha1 = "44e3b40da000eab4ccb1aecdc4801c040026aeb5"
+git-tree-sha1 = "14eece7a3308b4d8be910e265c724a6ba51a9798"
 uuid = "cd3eb016-35fb-5094-929b-558a96fad6f3"
-version = "0.9.13"
+version = "0.9.16"
 
 [[IniFile]]
 deps = ["Test"]
@@ -46,9 +46,9 @@ uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 
 [[JSON3]]
 deps = ["Dates", "Mmap", "Parsers", "StructTypes", "UUIDs"]
-git-tree-sha1 = "b3e5984da3c6c95bcf6931760387ff2e64f508f3"
+git-tree-sha1 = "7d58534ffb62cd947950b3aa9b993e63307a6125"
 uuid = "0f8b85d8-7281-11e9-16c2-39a750bddbf1"
-version = "1.9.1"
+version = "1.9.2"
 
 [[LibCURL]]
 deps = ["LibCURL_jll", "MozillaCACerts_jll"]
@@ -103,9 +103,9 @@ uuid = "ca575930-c2e3-43a9-ace4-1e988b2c1908"
 
 [[Parsers]]
 deps = ["Dates"]
-git-tree-sha1 = "438d35d2d95ae2c5e8780b330592b6de8494e779"
+git-tree-sha1 = "ae4bbcadb2906ccc085cf52ac286dc1377dceccc"
 uuid = "69de0a69-1ddd-5017-9359-2bf0b02dc9f0"
-version = "2.0.3"
+version = "2.1.2"
 
 [[Pkg]]
 deps = ["Artifacts", "Dates", "Downloads", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "REPL", "Random", "SHA", "Serialization", "TOML", "Tar", "UUIDs", "p7zip_jll"]
@@ -139,9 +139,9 @@ uuid = "6462fe0b-24de-5631-8697-dd941f90decc"
 
 [[StructTypes]]
 deps = ["Dates", "UUIDs"]
-git-tree-sha1 = "e36adc471280e8b346ea24c5c87ba0571204be7a"
+git-tree-sha1 = "d24a825a95a6d98c385001212dc9020d609f2d4f"
 uuid = "856f2bd8-1eba-4b0a-8007-ebc267875bd4"
-version = "1.7.2"
+version = "1.8.1"
 
 [[TOML]]
 deps = ["Dates"]

--- a/Project.toml
+++ b/Project.toml
@@ -19,6 +19,7 @@ SHA = "ea8e919c-243c-51af-8825-aaa63cd721ce"
 SimpleBufferStream = "777ac1f9-54b0-4bf8-805c-2214025038e7"
 Sockets = "6462fe0b-24de-5631-8697-dd941f90decc"
 StructTypes = "856f2bd8-1eba-4b0a-8007-ebc267875bd4"
+TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
 Tar = "a4e569a6-e804-4fa4-b0f3-eef7a1d5b13e"
 
 [compat]

--- a/bin/run_flavorless_server.jl
+++ b/bin/run_flavorless_server.jl
@@ -1,0 +1,11 @@
+#!/usr/bin/env julia
+using PkgServer, Sockets
+
+# This stub script only really used for testing, but feel free to adapt to your needs
+host = "127.0.0.1"
+port = 8001
+PkgServer.start(;
+    listen_addr=Sockets.InetAddr(host, port),
+    storage_root=mktempdir(),
+    dotflavors=[""],
+)

--- a/src/PkgServer.jl
+++ b/src/PkgServer.jl
@@ -99,8 +99,15 @@ function start(;kwargs...)
 
     # Update registries first thing
     @info("Performing initial registry update")
-    registry_flavor_list = ("eager", "conservative")
-    update_registries.(registry_flavor_list)
+    local registry_dotflavor_list
+    registry_dotflavor_list = (".eager", ".conservative")
+    if !any(update_registries.(registry_dotflavor_list))
+        @warn("Flavorless storage servers detected, falling back to flavorless mode")
+        registry_dotflavor_list = ("",)
+        if !any(update_registries.(registry_dotflavor_list))
+            error("Unable to get initial registry update!")
+        end
+    end
     global last_registry_update = now()
 
     # Experimental.@sync throws if _any_ of the tasks fail
@@ -110,7 +117,7 @@ function start(;kwargs...)
                 sleep(1)
                 @try_printerror begin
                     forget_failures()
-                    update_registries.(registry_flavor_list)
+                    update_registries.(registry_dotflavor_list)
                     last_registry_update = now()
                 end
             end

--- a/src/meta.jl
+++ b/src/meta.jl
@@ -154,6 +154,13 @@ function serve_json(http::HTTP.Stream, data)
     return serve_data(http, JSON3.write(data), "application/json")
 end
 
+function serve_redirect(http::HTTP.Stream, target::String)
+    HTTP.setheader(http, "Location" => target)
+    HTTP.setstatus(http, 302)
+    HTTP.startwrite(http)
+    return
+end
+
 libjulia_internal = C_NULL
 function get_num_live_tasks()
     global libjulia_internal

--- a/src/resource.jl
+++ b/src/resource.jl
@@ -10,17 +10,17 @@ const resource_re = Regex("""
 """, "x")
 
 """
-    get_registries(server)
+    get_registries(server, flavor)
 
 Interrogate a storage server for a list of registries, match the response against the
 registries we are paying attention to, return dict mapping from registry UUID to its
 latest treehash.
 """
-function get_registries(server::AbstractString)
+function get_registries(server::AbstractString, flavor::AbstractString)
     regs = Dict{String,String}()
-    response = HTTP.get("$server/registries", status_exception = false)
+    response = HTTP.get("$server/registries.$(flavor)", status_exception = false)
     if response.status != 200
-        @error("Failure to fetch /registries", server, response.status)
+        @error("Failure to fetch /registries.$(flavor)", server, response.status)
         return regs
     end
     for line in eachline(IOBuffer(response.body))
@@ -30,7 +30,7 @@ function get_registries(server::AbstractString)
             uuid in keys(config.registries) || continue
             regs[uuid] = hash
         else
-            @error("invalid response", server, resource="registries", line)
+            @error("invalid response", server, resource="registries.$(flavor)", line)
         end
     end
     return regs
@@ -126,12 +126,12 @@ function verify_registry_hash(uuid::AbstractString, hash::AbstractString)
     return url === nothing || url_exists(url)
 end
 
-function update_registries()
+function update_registries(flavor::String)
     # collect current registry hashes from servers
     regs = Dict(uuid => Dict{String,Vector{String}}() for uuid in keys(config.registries))
     servers = Dict(uuid => Vector{String}() for uuid in keys(config.registries))
     for server in config.storage_servers
-        for (uuid, hash) in get_registries(server)
+        for (uuid, hash) in get_registries(server, flavor)
             push!(get!(regs[uuid], hash, String[]), server)
             push!(servers[uuid], server)
         end
@@ -173,29 +173,33 @@ function update_registries()
                 wait(dl_state.dl_task)
             end
 
-            if config.registries[uuid].latest_hash != hash
+            if get(config.registries[uuid].hashes, flavor, "") != hash
                 @info("new current registry hash", uuid, hash, hash_servers)
                 changed = true
             end
 
             # we've got a new registry hash to serve
-            config.registries[uuid].latest_hash = hash
+            config.registries[uuid].hashes[flavor] = hash
             break
         end
     end
 
-    # write new registry info to file
-    registries_path = joinpath(config.root, "static", "registries")
-    if changed || !isfile(registries_path)
-        new_registries = joinpath(config.root, "temp", "registries.tmp." * randstring())
-        mkpath(dirname(new_registries))
-        open(new_registries, "w") do io
-            for uuid in sort!(collect(keys(config.registries)))
-                println(io, "/registry/$(uuid)/$(config.registries[uuid].latest_hash)")
+    # write new registry info to file, for each flavor we publish
+    for flavor in ("eager", "conservative")
+        registries_path = joinpath(config.root, "static", "registries.$(flavor)")
+        if changed || !isfile(registries_path)
+            new_registries = joinpath(config.root, "temp", "registries.$(flavor).tmp." * randstring())
+            mkpath(dirname(new_registries))
+            open(new_registries, "w") do io
+                for uuid in sort!(collect(keys(config.registries)))
+                    if haskey(config.registries[uuid].hashes, flavor)
+                        println(io, "/registry/$(uuid)/$(config.registries[uuid].hashes[flavor])")
+                    end
+                end
             end
+            mkpath(dirname(registries_path))
+            mv(new_registries, registries_path; force=true)
         end
-        mkpath(dirname(registries_path))
-        mv(new_registries, registries_path; force=true)
     end
     return changed
 end

--- a/test/debugging/registry_lag.jl
+++ b/test/debugging/registry_lag.jl
@@ -62,7 +62,7 @@ function get_general_time(treehash)
                 close(p.in)
                 @info("skip_treehash: $(skip_treehash)")
             end
-            prepare_for_deletion(dir)
+            Base.Filesystem.prepare_for_deletion(dir)
         end
 
         commit = commit_for_tree(reg_dir, skip_treehash)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -52,7 +52,7 @@ try
     @info("Running test suite with configuration", server_url, cache_dir)
     include("tests.jl")
 finally
-    if server_process != nothing
+    if server_process !== nothing
         @info("Reaping automatically-started local PkgServer...")
         kill(server_process)
         wait(server_process)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,9 +9,9 @@ using PkgServer, Pkg, TOML, HTTP, JSON3, Tar, Test
 
 # If these are not set, we will attempt to auto-initiate them.
 server_process = nothing
+code_dir = dirname(@__DIR__)
 if isempty(get(ENV, "JULIA_PKG_SERVER", "")) || isempty(get(ENV, "JULIA_PKG_SERVER_STORAGE_ROOT", ""))
     # Start a background PkgServer as a separate process
-    code_dir = dirname(@__DIR__)
     temp_dir = mktempdir()
     ENV["JULIA_PKG_SERVER"] = "http://127.0.0.1:8000"
     ENV["JULIA_PKG_SERVER_STORAGE_ROOT"] = temp_dir

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,4 @@
-using PkgServer, Pkg, Pkg.TOML, HTTP, JSON3, Tar, Test
+using PkgServer, Pkg, TOML, HTTP, JSON3, Tar, Test
 
 # You can either perform the following setup:
 #  - Already-running PkgServer, located at $JULIA_PKG_SERVER
@@ -6,28 +6,6 @@ using PkgServer, Pkg, Pkg.TOML, HTTP, JSON3, Tar, Test
 #
 # Or you can leave those blank, and we'll start up a PkgServer for you,
 # running on a background process.
-
-if VERSION < v"1.5"
-    error("These tests require a PkgServer-compatible Julia version!")
-end
-
-# "Backport" of JuliaLang/julia#37206
-function prepare_for_deletion(path::AbstractString)
-    # Nothing to do for non-directories
-    if !isdir(path)
-        return
-    end
-
-    try chmod(path, filemode(path) | 0o333)
-    catch; end
-    for (root, dirs, files) in walkdir(path)
-        for dir in dirs
-            dpath = joinpath(root, dir)
-            try chmod(dpath, filemode(dpath) | 0o333)
-            catch; end
-        end
-    end
-end
 
 # If these are not set, we will attempt to auto-initiate them.
 server_process = nothing
@@ -63,5 +41,3 @@ finally
         end
     end
 end
-
-(@isdefined temp_dir) && prepare_for_deletion(temp_dir)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -21,6 +21,9 @@ if isempty(get(ENV, "JULIA_PKG_SERVER", "")) || isempty(get(ENV, "JULIA_PKG_SERV
     global server_process = run(`$(Base.julia_cmd()) --project=$(code_dir) $(code_dir)/bin/run_server.jl`; wait=false)
 end
 
+# Ensure that we don't end up spending time precompiling when we install stuff; it's useless
+ENV["JULIA_PKG_PRECOMPILE_AUTO"]="0"
+
 server_url = ENV["JULIA_PKG_SERVER"]
 cache_dir = joinpath(ENV["JULIA_PKG_SERVER_STORAGE_ROOT"], "cache")
 

--- a/test/tests.jl
+++ b/test/tests.jl
@@ -140,7 +140,7 @@ end
             Pkg.add(Pkg.PackageSpec(;name="DotNET", version=v"0.1.0"))
             Pkg.add(Pkg.PackageSpec(;name="FIGlet", version=v"0.2.1"))
         end
-        prepare_for_deletion(temp_dir)
+        Base.Filesystem.prepare_for_deletion(temp_dir)
     end
 
     # Sleep until there's nothing left in the `temp` directory.


### PR DESCRIPTION
The storage server now exports two different "flavors" of registry
declarations, `eager` and `conservative`:

- `eager` registries are published as soon as possible, and should track
upstream git repositories quite closely, (in general, it should be less
than two minutes behind the state of the upstream git repository).  The
downside is that the storage server may not have processed some of the
resources in the registry, so if you are a user behind a restrictive
firewall and cannot download resources off of arbitrary servers, we
suggest you use the `conservative` registry.

- `conservative` registries are published only once the StorageServer
has at least tried to process all resources (packages, artifacts,
etc...) within a registry.  It does not guarantee that all resources are
downloadable (after all, there are some package versions that contain
links to artifacts that simply do not exist) but it gives a "best
effort" treehash to use.  The downside is that in the event that a large
number of new resources have been added to the registry recently, it may
take a little while for the storage server to process them all, so the
`conservative` registry flavor may lag behind real-time by a few hours.

Pkg clients that ask for `/registries` are, by default, served a
`conservative` registry, unless one of the following two conditions
hold:

- The Pkg client declares itself to be running CI (via one of the CI
  variables transmitted in the `Julia-Ci-Variables` header, see [0] for
  more), in which case we assume you likely want `eager`.

- The Pkg client transmits a `Julia-Registry-Preference` header set to
  one of the valid flavors, which currently includes `eager` and
  `conservative`.

Now that [1] has been merged into `Pkg.jl`, users can easily set their
own preference header by simply defining the environment mapping
`JULIA_PKG_SERVER_REGISTRY_PREFERENCE=eager`.

[0] https://github.com/JuliaLang/Pkg.jl/blob/bb180de2802a8320241e10721c1ac4eefd3eb27d/src/PlatformEngines.jl#L200-L213

[1] JuliaLang/Pkg.jl#2770