### PR TITLE
Tighten down healthcheck timings, use `autoheal` to do the restarting

### DIFF
--- a/deployment/docker-compose.yml
+++ b/deployment/docker-compose.yml
@@ -19,9 +19,9 @@ services:
             JULIA_PKG_SERVER_STORAGE_SERVERS: "${STORAGE_SERVERS:-https://us-east.storage.juliahub.com,https://kr.storage.juliahub.com}"
         labels:
             com.centurylinklabs.watchtower.scope: "pkgserver.jl"
-            autoheal: true
+            autoheal: "true"
         healthcheck:
-            test: ["CMD", "curl -f -m 1 'http://localhost:8000/meta'"]
+            test: ["CMD", "curl", "-f", "-m", "1", "http://localhost:8000/meta"]
             interval: 30s
             timeout: 2s
             retries: 3

--- a/deployment/docker-compose.yml
+++ b/deployment/docker-compose.yml
@@ -19,12 +19,13 @@ services:
             JULIA_PKG_SERVER_STORAGE_SERVERS: "${STORAGE_SERVERS:-https://us-east.storage.juliahub.com,https://kr.storage.juliahub.com}"
         labels:
             com.centurylinklabs.watchtower.scope: "pkgserver.jl"
+            autoheal: true
         healthcheck:
-            test: curl -f --retry 5 --max-time 5 --retry-delay 10 --retry-max-time 60 "http://localhost:8000/meta" || bash -c 'kill -s 15 $$(pidof julia) && (sleep 10; kill -s 9 $$(pidof julia))'
-            interval: 2m
-            timeout: 10s
+            test: ["CMD", "curl -f -m 1 'http://localhost:8000/meta'"]
+            interval: 30s
+            timeout: 2s
             retries: 3
-            start_period: 5m
+            start_period: 2m
     
     frontend:
         image: jonasal/nginx-certbot
@@ -63,5 +64,12 @@ services:
         labels:
             com.centurylinklabs.watchtower.scope: "pkgserver.jl"
 
+    # Auto restart docker containers when their status is reported as unhealthy
+    autoheal:
+        image: willfarrell/autoheal
+        restart: unless-stopped
+        volumes:
+            # Mount the docker socket
+            - /var/run/docker.sock:/var/run/docker.sock
 volumes:
     letsencrypt:

--- a/src/PkgServer.jl
+++ b/src/PkgServer.jl
@@ -238,7 +238,7 @@ function start(;kwargs...)
                     HTTP.setheader(http, "X-Cache-Miss" => "miss")
                     stream_path = temp_resource_filepath(resource)
                     # Wait until `stream_path` is created
-                    while !isfile(stream_path) && dl_state.dl_task.state != :done
+                    while !isfile(stream_path) && !istaskdone(dl_state.dl_task)
                         sleep(0.001)
                     end
                     # Try to serve `stream_path` file


### PR DESCRIPTION
This should make it easier for us to debug healthcheck issues