### PR TITLE
Add `registry_update_period` setting

### DIFF
--- a/bin/run_server.jl
+++ b/bin/run_server.jl
@@ -18,6 +18,7 @@ storage_root = get(ENV, "JULIA_PKG_SERVER_STORAGE_ROOT", "/tmp/pkgserver")
 storage_servers = strip.(split(get(ENV, "JULIA_PKG_SERVER_STORAGE_SERVERS", "https://us-east.storage.juliahub.com,https://kr.storage.juliahub.com"), ","))
 log_dir = get(ENV, "JULIA_PKG_SERVER_LOGS_DIR", joinpath(storage_root, "logs"))
 flavorless = get(ENV, "JULIA_PKG_SERVER_FLAVORLESS", "false")
+registry_update_period = parse(Float64, get(ENV, "JULIA_PKG_SERVER_REGISTRY_UPDATE_PERIOD", "1"))
 
 dotflavors = [
     ".eager",
@@ -66,4 +67,5 @@ PkgServer.start(;
     storage_root,
     storage_servers,
     dotflavors,
+    registry_update_period,
 )

--- a/deployment/Makefile
+++ b/deployment/Makefile
@@ -18,6 +18,7 @@ DISABLE_TLS := $(shell bash -c "source .env 2>/dev/null && echo \$$DISABLE_TLS")
 DISABLE_INTERNAL_DNS := $(shell bash -c "source .env 2>/dev/null && echo \$$DISABLE_INTERNAL_DNS")
 DISABLE_INTERNAL_DNS_IPV6 := $(shell bash -c "source .env 2>/dev/null && echo \$$DISABLE_INTERNAL_DNS_IPV6")
 PKG_SERVER_FLAVORLESS := $(shell bash -c "source .env 2>/dev/null && echo \$$FLAVLORLESS")
+UPDATE_PERIOD := $(shell bash -c "source .env 2>/dev/null && echo \$$UPDATE_PERIOD")
 
 # If `DISABLE_TLS` is defined, use the `http` stanza instead of the `tls` one.
 LISTEN_SRC := $(if $(DISABLE_TLS),conf/stanza_http.conf,conf/stanza_tls.conf)

--- a/deployment/docker-compose.yml
+++ b/deployment/docker-compose.yml
@@ -18,6 +18,7 @@ services:
             JULIA_PKG_SERVER_FQDN: "${PKG_SERVER_FQDN}"
             JULIA_PKG_SERVER_STORAGE_SERVERS: "${STORAGE_SERVERS:-https://us-east.storage.juliahub.com,https://kr.storage.juliahub.com}"
             JULIA_PKG_SERVER_FLAVORLESS: "${PKG_SERVER_FLAVORLESS:-false}"
+            JULIA_PKG_SERVER_REGISTRY_UPDATE_PERIOD: "${UPDATE_PERIOD:-1}"
         labels:
             com.centurylinklabs.watchtower.scope: "pkgserver.jl"
             autoheal: "true"


### PR DESCRIPTION
This allows us to easily set a different registry update period, so that we update our registries more slowly than once per second when dealing with servers other than our own.