### PR TITLE
Expose http ports also when SSL is configured

### DIFF
--- a/bin/run_flavorless_server.jl
+++ b/bin/run_flavorless_server.jl
@@ -3,7 +3,7 @@ using PkgServer, Sockets
 
 # This stub script only really used for testing, but feel free to adapt to your needs
 host = "127.0.0.1"
-port = 8001
+port = 8002
 PkgServer.start(;
     listen_addr=Sockets.InetAddr(host, port),
     storage_root=mktempdir(),

--- a/deployment/conf/stanza_tls.conf
+++ b/deployment/conf/stanza_tls.conf
@@ -1,3 +1,5 @@
+    listen              8000;
+    listen              [::]:8000;
     listen              443 ssl http2;
     listen              [::]:443 ssl http2;
     server_name         ${SERVERNAMES};

--- a/deployment/docker-compose.yml
+++ b/deployment/docker-compose.yml
@@ -7,6 +7,8 @@ services:
         restart: unless-stopped
         expose:
             - 8000
+        ports:
+            - 8001:8000/tcp
         volumes:
             - ./storage:/app/storage
             - ./logs/pkgserver:/app/logs
@@ -28,7 +30,7 @@ services:
             timeout: 2s
             retries: 3
             start_period: 5m
-    
+
     frontend:
         image: jonasal/nginx-certbot:3.3.1
         restart: unless-stopped

--- a/test/tests.jl
+++ b/test/tests.jl
@@ -304,7 +304,7 @@ end
 
 @testset "Flavorless" begin
     # Start another (very short-lived) PkgServer
-    flavorless_server_url = "http://127.0.0.1:8001"
+    flavorless_server_url = "http://127.0.0.1:8002"
     server_env = Dict(
         "JULIA_PKG_SERVER" => flavorless_server_url,
         "JULIA_PKG_SERVER_STORAGE_ROOT" => mktempdir(),


### PR DESCRIPTION
This patch changes the nginx configuration to always listen for http requests on port 8000 and forward them to the upstream package server.

In addition, the docker compose configuration is changed to map port 8001 on the host to port 8000 in the container. This make it possible to bypass nginx and connect directly to the package server.

To make use of these ports one needs to be on tailnet or use SSH port forwarding. In the standard configuration ports 8000 and 8001 are both blocked by the firewall so there are no plain http ports exposed to the public.