### PR TITLE
Use hex output in token generation example

### DIFF
--- a/deployment/.gitignore
+++ b/deployment/.gitignore
@@ -1,5 +1,6 @@
 # Ignore local configuration setup
 .env
+*.secret
 
 # Ignore locally-mounted `storage` and `logs` directories
 storage/

--- a/src/admin.jl
+++ b/src/admin.jl
@@ -20,8 +20,8 @@ include("admin_logging.jl")
 #
 # The token and the hash can, for example, be setup as with the following commands:
 # ```
-# openssl rand 32 \
-#     | openssl enc -A -base64 \
+# openssl rand -hex 32 \
+#     | head -c -1 \
 #     | tee admin_token.secret \
 #     | sha256sum - \
 #     | cut -d ' ' -f 1 \


### PR DESCRIPTION
Hex output is easier to work with in URLs since it doesn't contain special characters.