### PR TITLE
Disable response buffering for /admin/logs

### DIFF
--- a/src/admin.jl
+++ b/src/admin.jl
@@ -104,6 +104,9 @@ function handle_admin_authenticated(http::HTTP.Stream)
         color = get(params, "color", "true") == "true"
         req_level = get(params, "level", "info") == "debug" ? Logging.Debug : Logging.Info
         HTTP.setheader(http, "Content-Type" => "text/plain")
+        # Tell nginx to not buffer the response, see
+        # https://www.nginx.com/resources/wiki/start/topics/examples/x-accel/#x-accel-buffering
+        HTTP.setheader(http, "X-Accel-Buffering" => "no")
         HTTP.startwrite(http)
         attach(ADMIN_LOGGER) do level, message
             level < req_level && return


### PR DESCRIPTION
This patch disables buffering for the streaming endpoint /admin/logs by setting the special nginx proxy response header X-Accel-Buffering to "no". Even though the default buffering settings seems to work fairly well without too many buffer hiccups it is recommended to disable buffering for this type of streaming endpoints.

As an alternative, buffering can be disabled in the nginx config by introducing a new /admin/logs location block, but since the scope here is very narrow it seems much simpler to just set the header.