### PR TITLE
Notify PkgServer.jl about nginx cache hits

### DIFF
--- a/deployment/conf/pkgserver.nginx.conf
+++ b/deployment/conf/pkgserver.nginx.conf
@@ -10,6 +10,12 @@ real_ip_header X-Real-IP;
 # This proxy cache provides Julia download caching
 proxy_cache_path /caches/s3 levels=1:2 keys_zone=s3cache:1m max_size=10g min_free=3g inactive=7d use_temp_path=off;
 
+# Only set $original_uri for internal redirects to /notify
+map $uri $original_uri {
+    default '';
+    /notify $request_uri;
+}
+
 server {
     # This block of code templated in from ${LISTEN_BLOCK_SRC}
 ${LISTEN_BLOCK}
@@ -24,11 +30,21 @@ ${LISTEN_BLOCK}
 
         root /caches/pkgserver/cache;
         try_files $uri @pkgserver;
+
+        # Notify PkgServer about this cache hit
+        mirror /notify;
+        mirror_request_body off;
     }
     location /registries {
         add_header Content-Type text/plain;
         root /caches/pkgserver/static;
         try_files $uri @pkgserver;
+    }
+
+    # Internal block for notifying PkgServer about cache hits.
+    location = /notify {
+        internal;
+        try_files /dev/null @pkgserver;
     }
 
     # Our default mode is to proxy things off to the `@pkgserver`.  This `try_files` directive
@@ -46,6 +62,7 @@ ${LISTEN_BLOCK}
         proxy_set_header X-Forwarded-Proto $scheme;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Request-ID $http_x_request_id;
+        proxy_set_header X-Original-URI $original_uri;
     }
 
     # We provide an S3 mirror for each bucket defined in S3_MIRROR_BUCKET_LIST

--- a/src/meta.jl
+++ b/src/meta.jl
@@ -147,7 +147,7 @@ function serve_data(http::HTTP.Stream, msg, content_type)
     startwrite(http)
     if http.message.method == "GET"
         written_bytes = write(http, msg)
-        Prometheus.inc(BYTES_SENT, written_bytes)
+        Prometheus.inc(BYTES_TRANSMITTED, written_bytes)
     end
     return
 end

--- a/src/metrics.jl
+++ b/src/metrics.jl
@@ -49,9 +49,15 @@ const BYTES_RECEIVED = Prometheus.Counter(
     registry = COLLECTOR_REGISTRY,
 )
 
-const BYTES_SENT = Prometheus.Counter(
-    "pkgserver_sent_bytes_total",
-    "Total number of bytes sent to clients";
+const BYTES_TRANSMITTED = Prometheus.Counter(
+    "pkgserver_transmitted_bytes_total",
+    "Total number of bytes transmitted to clients";
+    registry = COLLECTOR_REGISTRY,
+)
+
+const NGINX_BYTES_TRANSMITTED = Prometheus.Counter(
+    "nginx_pkgserver_transmitted_bytes_total",
+    "Total number of bytes transmitted to clients by nginx";
     registry = COLLECTOR_REGISTRY,
 )
 

--- a/src/resource.jl
+++ b/src/resource.jl
@@ -578,7 +578,7 @@ function serve_file(http::HTTP.Stream,
     if http.message.method == "GET"
         transmitted = stream_file(io, startbyte, content_length, dl_task, http, buffer)
         global payload_bytes_transmitted += transmitted
-        Prometheus.inc(BYTES_SENT, transmitted)
+        Prometheus.inc(BYTES_TRANSMITTED, transmitted)
         if transmitted != content_length
             @error("file size mismatch", content_length, actual=transmitted)
         end


### PR DESCRIPTION
As described in #198, the file cache is unaware of cache hits for files served directly by nginx. This patch notifies PkgServer.jl about nginx cache hits by sending a mirrored request to the internal /notify endpoint. The original request URI is sent through the `X-Original-URI` header and is used to record the cache hit. In addition, since any cache hits are for files already existing in the cache we can record the size as bytes sent by nginx in a Prometheus counter.