### PR TITLE
Misc updates

### DIFF
--- a/deployment/conf/pkgserver.nginx.conf
+++ b/deployment/conf/pkgserver.nginx.conf
@@ -71,3 +71,16 @@ ${MIRROR_BLOCK}
     access_log /logs/access_${FQDN}.log pkgserver_logformat buffer=4k flush=1m;
     error_log  /logs/error_${FQDN}.log;
 }
+
+# Expose basic status information on /stub_status to be consumed by nginx-prometheus-exporter
+# https://nginx.org/en/docs/http/ngx_http_stub_status_module.html#stub_status
+server {
+    listen 8080;
+    listen [::]:8080;
+    location = /stub_status {
+        stub_status;
+    }
+    location / {
+        return 444;
+    }
+}

--- a/deployment/conf/stanza_tls.conf
+++ b/deployment/conf/stanza_tls.conf
@@ -1,7 +1,8 @@
     listen              8000;
     listen              [::]:8000;
-    listen              443 ssl http2;
-    listen              [::]:443 ssl http2;
+    listen              443 ssl;
+    listen              [::]:443 ssl;
+    http2               on;
     server_name         ${SERVERNAMES};
     ssl_certificate     /etc/letsencrypt/live/${FQDN}/fullchain.pem;
     ssl_certificate_key /etc/letsencrypt/live/${FQDN}/privkey.pem;

--- a/deployment/docker-compose.yml
+++ b/deployment/docker-compose.yml
@@ -1,5 +1,4 @@
 # This is the production docker-compose setup, complete with nginx TLS terminator
-version: '3.4'
 services:
     pkgserver:
         image: juliapackaging/pkgserver.jl
@@ -32,7 +31,7 @@ services:
             start_period: 5m
 
     frontend:
-        image: jonasal/nginx-certbot:3.3.1
+        image: jonasal/nginx-certbot:5.0.1
         restart: unless-stopped
         environment:
             CERTBOT_EMAIL: "${CERTBOT_EMAIL:-info@foobar.com}"
@@ -40,6 +39,7 @@ services:
             - 80:80/tcp
             - 443:443/tcp
             - 8000:8000/tcp
+            - 8080:8080/tcp # nginx /stub_status
         depends_on:
             - pkgserver
         volumes:

--- a/loadbalancer/conf/loadbalancer.nginx.conf
+++ b/loadbalancer/conf/loadbalancer.nginx.conf
@@ -20,12 +20,13 @@ ${PKGSERVERS_SERVER_BLOCK}
 }
 
 server {
-    listen              443 ssl http2;
-    listen              [::]:443 ssl http2;
+    listen              443 ssl;
+    listen              [::]:443 ssl;
+    http2               on;
     server_name         ${REGION}.pkg.julialang.org loadbalancer-${REGION}.ip.cflo.at loadbalancer-${REGION}.ipv4.cflo.at loadbalancer-${REGION}.ipv6.cflo.at;
     ssl_certificate     /etc/letsencrypt/live/${FQDN}/fullchain.pem;
     ssl_certificate_key /etc/letsencrypt/live/${FQDN}/privkey.pem;
-    
+
     # We pass all content-addressed URLs off to consistent PkgServer locations,
     # so that each package server only needs to keep track of a portion of these resources
     location ~ /(registry|package|artifact|mirror)/ {
@@ -33,7 +34,6 @@ server {
         set $upstream pkgservers_hashed;
         try_files $uri @loadbalance;
     }
-
     # Everything else (`/registries`, `/meta`, etc...) gets round-robined
     location / {
         proxy_next_upstream error timeout;
@@ -64,4 +64,17 @@ server {
 
     access_log /logs/access_${FQDN}.log pkgserver_logformat buffer=4k flush=1m;
     error_log  /logs/error_${FQDN}.log;
+}
+
+# Expose basic status information on /stub_status to be consumed by nginx-prometheus-exporter
+# https://nginx.org/en/docs/http/ngx_http_stub_status_module.html#stub_status
+server {
+    listen 8080;
+    listen [::]:8080;
+    location = /stub_status {
+        stub_status;
+    }
+    location / {
+        return 444;
+    }
 }

--- a/loadbalancer/docker-compose.yml
+++ b/loadbalancer/docker-compose.yml
@@ -1,8 +1,7 @@
 # This is the production docker-compose setup, complete with nginx TLS terminator
-version: '2.3'
 services:
     loadbalancer:
-        image: jonasal/nginx-certbot:3.3.1
+        image: jonasal/nginx-certbot:5.0.1
         restart: unless-stopped
         environment:
             CERTBOT_EMAIL: "${CERTBOT_EMAIL:-info@foobar.com}"


### PR DESCRIPTION
 - Expose nginx basic stats on port 8080 to be consumed by Prometheus.
 - Use the nginx directive `http on;` instead of the deprecated `listen http2;`
 - Remove deprecated `version:` field in docker compose files.
 - Update nginx docker image.