### PR TITLE
Use sudo to force-create nginx log files with correct permissions

### DIFF
--- a/deployment/Makefile
+++ b/deployment/Makefile
@@ -53,8 +53,7 @@ $(DIRS):
 # nginx master process (running as root) creates them with root as owner.
 NGINX_CURRENT_LOGFILES := logs/nginx/access_${PKG_SERVER_FQDN}.log logs/nginx/error_${PKG_SERVER_FQDN}.log
 $(NGINX_CURRENT_LOGFILES): logs/nginx
-	touch $@
-	chmod 0644 $@
+	sudo touch $@ && sudo chown $(UID):$(GID) $@ && chmod 0644 $@
 
 # Make sure files have the expected permissions: the nginx master process runs
 # as root and sometimes files created by this process trips up the package

--- a/loadbalancer/Makefile
+++ b/loadbalancer/Makefile
@@ -30,8 +30,7 @@ $(DIRS):
 # Make sure nginx log files are created before starting nginx.
 NGINX_CURRENT_LOGFILES := logs/nginx/access_${SERVER_FQDN}.log logs/nginx/error_${SERVER_FQDN}.log
 $(NGINX_CURRENT_LOGFILES): logs/nginx
-	touch $@
-	chmod 0644 $@
+	sudo touch $@ && sudo chown $(UID):$(GID) $@ && chmod 0644 $@
 
 # Make sure files have the expected permissions
 filepermissions: logs/nginx $(NGINX_CURRENT_LOGFILES)


### PR DESCRIPTION
This is only needed to upgrade legacy servers where the log files might already exist but doesn't hurt to always do this.