### PR TITLE
Another round of misc fixes

### DIFF
--- a/deployment/Makefile
+++ b/deployment/Makefile
@@ -1,9 +1,6 @@
 # Default target is to bring everything up
 all: up
 
-# Use docker compose if it exist, fall back to docker-compose
-COMPOSE=$(shell if docker compose version >/dev/null 2>&1; then echo "docker compose"; else echo "docker-compose"; fi)
-
 # Extract configuration from `.env` file
 PKG_SERVER_REGION := $(shell bash -c "source .env 2>/dev/null && echo \$$PKG_SERVER_REGION")
 ifeq ($(PKG_SERVER_REGION),)
@@ -80,13 +77,13 @@ build/pkgserver.nginx.conf: conf/pkgserver.nginx.conf ${LISTEN_SRC} | build
 	envsubst '$${LISTEN_BLOCK_SRC} $${LISTEN_BLOCK} $${MIRROR_BLOCK} $${REGION} $${FQDN}' < $< > $@
 
 up: $(DIRS) build/pkgserver.nginx.conf
-	${COMPOSE} up --build --remove-orphans -d
+	docker compose up --build --remove-orphans -d
 
 down:
-	${COMPOSE} down --remove-orphans
+	docker compose down --remove-orphans
 
 pull:
-	${COMPOSE} pull
+	docker compose pull
 
 # Rule to install logrotate configuration so that host-wide logrotate can
 # perform the logrotations, as well as run `make nginx-send-usr1`.
@@ -99,7 +96,7 @@ include logrotate.make
 
 # Rule to send nginx USR1 signal via docker compose (used by `logrotate.conf`)
 nginx-send-usr1:
-	${COMPOSE} exec -T frontend /bin/bash -c 'kill -USR1 `pgrep -f "nginx: [m]aster"`'
+	docker compose exec -T frontend /bin/bash -c 'kill -USR1 `pgrep -f "nginx: [m]aster"`'
 
 PYTHON := "$(shell which python3 2>/dev/null || which python 2>/dev/null || which python2 2>/dev/null || echo "{python|python3|python2} not found")"
 PYTHONPATH := $(shell $(PYTHON) -c "import sys; print(':'.join(sys.path[1:]))")
@@ -124,19 +121,19 @@ dev-up:
 	
 
 stop-watchtower:
-	${COMPOSE} stop watchtower
+	docker compose stop watchtower
 
 trigger-watchtower:
-	${COMPOSE} run --rm watchtower --cleanup --scope pkgserver.jl --run-once
+	docker compose run --rm watchtower --cleanup --scope pkgserver.jl --run-once
 
 logs:
-	${COMPOSE} logs -f --tail=100
+	docker compose logs -f --tail=100
 .PHONY: logs
 
 # TODO: In the future we can remove /etc/cron.hourly/pkgserver but keep it here
 # for now so that we can cleanup the files we installed in the past.
 destroy:
-	${COMPOSE} down -v --remove-orphans
+	docker compose down -v --remove-orphans
 	rm -rf logs storage build
 	sudo rm -f /etc/cron.hourly/pkgserver /etc/cron.daily/pkgserver /etc/logrotate.d/pkgserver
 

--- a/deployment/Makefile
+++ b/deployment/Makefile
@@ -98,6 +98,10 @@ include logrotate.make
 nginx-send-usr1:
 	docker compose exec -T frontend /bin/bash -c 'kill -USR1 `pgrep -f "nginx: [m]aster"`'
 
+# Rule to send nginx HUP signal to reload configuration
+nginx-send-hup:
+	docker compose kill --signal=SIGHUP frontend
+
 PYTHON := "$(shell which python3 2>/dev/null || which python 2>/dev/null || which python2 2>/dev/null || echo "{python|python3|python2} not found")"
 PYTHONPATH := $(shell $(PYTHON) -c "import sys; print(':'.join(sys.path[1:]))")
 /etc/cron.daily/pkgserver: conf/cron.restart.conf

--- a/deployment/Makefile
+++ b/deployment/Makefile
@@ -49,7 +49,7 @@ $(DIRS):
 # Make sure nginx log files are created before starting nginx. Without this the
 # nginx master process (running as root) creates them with root as owner.
 NGINX_CURRENT_LOGFILES := logs/nginx/access_${PKG_SERVER_FQDN}.log logs/nginx/error_${PKG_SERVER_FQDN}.log
-$(NGINX_CURRENT_LOGFILES): logs/nginx
+$(NGINX_CURRENT_LOGFILES): logs/nginx .env
 	touch $@
 	chmod 0644 $@
 
@@ -62,7 +62,7 @@ filepermissions: $(DIRS) $(NGINX_CURRENT_LOGFILES)
 up: filepermissions
 
 # If our pkgserver is given a FQDN, then we splice in the TLS stanza, otherwise the HTTP stanza
-build/pkgserver.nginx.conf: conf/pkgserver.nginx.conf ${LISTEN_SRC} | build
+build/pkgserver.nginx.conf: conf/pkgserver.nginx.conf ${LISTEN_SRC} .env | build
 	@export FQDN="$(PKG_SERVER_FQDN)"; \
 	export SERVERNAMES="$(SERVERNAMES)"; \
 	export LISTEN_BLOCK_SRC=$(LISTEN_SRC); \

--- a/loadbalancer/Makefile
+++ b/loadbalancer/Makefile
@@ -26,7 +26,7 @@ $(DIRS):
 
 # Make sure nginx log files are created before starting nginx.
 NGINX_CURRENT_LOGFILES := logs/nginx/access_${SERVER_FQDN}.log logs/nginx/error_${SERVER_FQDN}.log
-$(NGINX_CURRENT_LOGFILES): logs/nginx
+$(NGINX_CURRENT_LOGFILES): logs/nginx .env
 	touch $@
 	chmod 0644 $@
 

--- a/loadbalancer/Makefile
+++ b/loadbalancer/Makefile
@@ -68,6 +68,10 @@ include ../deployment/logrotate.make
 nginx-send-usr1:
 	docker compose exec -T loadbalancer /bin/bash -c 'kill -USR1 `pgrep -f "nginx: [m]aster"`'
 
+# Rule to send nginx HUP signal to reload configuration
+nginx-send-hup:
+	docker compose kill --signal=SIGHUP loadbalancer
+
 stop-watchtower:
 	docker compose stop watchtower
 

--- a/loadbalancer/Makefile
+++ b/loadbalancer/Makefile
@@ -5,9 +5,6 @@ all: up
 COMMA:=,
 SPACE:=$(eval) $(eval)
 
-# Use docker compose if it exist, fall back to docker-compose
-COMPOSE=$(shell if docker compose version >/dev/null 2>&1; then echo "docker compose"; else echo "docker-compose"; fi)
-
 # Extract configuration from `.env` file
 SERVER_REGION := $(shell bash -c "source .env 2>/dev/null && echo \$$SERVER_REGION")
 PKGSERVERS := $(shell bash -c "source .env 2>/dev/null && echo \$$PKGSERVERS")
@@ -53,10 +50,10 @@ build/children.json: .env | build
 up: build/children.json
 
 up: $(DIRS) build/loadbalancer.nginx.conf
-	${COMPOSE} up --build --remove-orphans -d
+	docker compose up --build --remove-orphans -d
 
 down:
-	${COMPOSE} down --remove-orphans
+	docker compose down --remove-orphans
 
 # Rule to install logrotate configuration so that host-wide logrotate can
 # perform the logrotations, as well as run `make nginx-send-usr1`.
@@ -69,19 +66,19 @@ include ../deployment/logrotate.make
 
 # Rule to send nginx USR1 signal via docker compose (used by `logrotate.conf`)
 nginx-send-usr1:
-	${COMPOSE} exec -T loadbalancer /bin/bash -c 'kill -USR1 `pgrep -f "nginx: [m]aster"`'
+	docker compose exec -T loadbalancer /bin/bash -c 'kill -USR1 `pgrep -f "nginx: [m]aster"`'
 
 stop-watchtower:
-	${COMPOSE} stop watchtower
+	docker compose stop watchtower
 
 logs:
-	${COMPOSE} logs -f --tail=100
+	docker compose logs -f --tail=100
 .PHONY: logs
 
 # TODO: In the future we can remove /etc/cron.hourly/loadbalancer but keep it here
 # for now so that we can cleanup the files we installed in the past.
 destroy:
-	${COMPOSE} down -v --remove-orphans
+	docker compose down -v --remove-orphans
 	rm -rf logs build
 	sudo rm -f /etc/cron.hourly/loadbalancer /etc/logrotate.d/loadbalancer
 

--- a/test/perf/Makefile
+++ b/test/perf/Makefile
@@ -1,15 +1,12 @@
 SRCDIR := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
 
-# Use docker compose if it exist, fall back to docker-compose
-COMPOSE=$(shell if docker compose version >/dev/null 2>&1; then echo "docker compose"; else echo "docker-compose"; fi)
-
 K6 := docker run --rm -v $(SRCDIR):/config:ro -v $(SRCDIR)/results:/results --net=host -ti loadimpact/k6
 
 up:
-	${COMPOSE} up -d --remove-orphans
+	docker compose up -d --remove-orphans
 
 down:
-	${COMPOSE} down -v --remove-orphans
+	docker compose down -v --remove-orphans
 
 results:
 	mkdir -p $@


### PR DESCRIPTION
 - Force usage of `docker compose` explicitly everywhere to not get stuck with old docker-compose binaries
 - Add .env as prerequisite on some missing targets
 - Add make target to reload nginx