### PR TITLE
Fix CI bot detection based on the `Julia-CI-Variables` header

### DIFF
--- a/src/PkgServer.jl
+++ b/src/PkgServer.jl
@@ -273,7 +273,7 @@ function handle_request(http::HTTP.Stream)
         # out which registry flavor they actually want, and if none is given,
         # give them `conservative` by default, unless they are self-reporting
         # as a CI bot, in which case we'll always point them to `eager`.
-        ci = any([v == "t" for (k, v) in filter(!isempty, split(HTTP.header(http, "Julia-CI-Variables", ""), ";"))])
+        ci = any([v == "t" for (k, v) in split.(filter(!isempty, split(HTTP.header(http, "Julia-CI-Variables", ""), ";")), "=")])
         flavor = HTTP.header(http, "Julia-Registry-Preference", ci ? "eager" : "conservative")
         serve_redirect(http, "/registries.$(flavor)")
         return

--- a/src/PkgServer.jl
+++ b/src/PkgServer.jl
@@ -273,7 +273,7 @@ function handle_request(http::HTTP.Stream)
         # out which registry flavor they actually want, and if none is given,
         # give them `conservative` by default, unless they are self-reporting
         # as a CI bot, in which case we'll always point them to `eager`.
-        ci = any([v == "t" for (k, v) in split.(filter(!isempty, split(HTTP.header(http, "Julia-CI-Variables", ""), ";")), "=")])
+        ci = any(x -> occursin(r"=t$", x), split(HTTP.header(http, "Julia-CI-Variables", ""), ";"))
         flavor = HTTP.header(http, "Julia-Registry-Preference", ci ? "eager" : "conservative")
         serve_redirect(http, "/registries.$(flavor)")
         return

--- a/test/tests.jl
+++ b/test/tests.jl
@@ -63,6 +63,13 @@ end
     response = HTTP.get("$(server_url)/registries"; redirect=false)
     @test response.status == 302
 
+    # Hitting `/registries` while reporting as a CI service should default to
+    # serving the eager flavor and the conservative flavor otherwise
+    conservative_response = HTTP.get("$(server_url)/registries")
+    @test endswith(conservative_response.request.target, ".conservative")
+    eager_response = HTTP.get("$(server_url)/registries", ["Julia-CI-Variables" => "CI=t"])
+    @test endswith(eager_response.request.target, ".eager")
+
     # Test asking for that registry directly, unpacking it and verifying the treehash
     mktemp() do tarball_path, tarball_io
         response = HTTP.get("$(server_url)/registry/$(registry_uuid)/$(registry_treehash)"; response_stream=tarball_io)


### PR DESCRIPTION
I was messing about hitting the `/registries` endpoint while configuring the `Julia-CI-Variables` header and noticed that none of the values I set resulted in getting the "eager" flavor.

It turns out the previous implementation would only end up checking the first two characters of each semi-colon separated entry in the header, effectively causing CI bots to not be detected.