### PR TITLE
Simplify nginx-send-usr1 make target

### DIFF
--- a/deployment/Makefile
+++ b/deployment/Makefile
@@ -96,7 +96,7 @@ include logrotate.make
 
 # Rule to send nginx USR1 signal via docker compose (used by `logrotate.conf`)
 nginx-send-usr1:
-	docker compose exec -T frontend /bin/bash -c 'kill -USR1 `pgrep -f "nginx: [m]aster"`'
+	docker compose kill --signal=SIGUSR1 frontend
 
 # Rule to send nginx HUP signal to reload configuration
 nginx-send-hup:

--- a/deployment/docker-compose.yml
+++ b/deployment/docker-compose.yml
@@ -35,7 +35,7 @@ services:
         build:
           context: .
           dockerfile_inline: |
-            FROM jonasal/nginx-certbot:5.0.1
+            FROM jonasal/nginx-certbot:5.2.0
             RUN groupadd --gid ${GID} nginx-host-uid && \
                 useradd --gid nginx-host-uid --no-create-home --home /nonexistent --comment "nginx user with host uid" --shell /bin/false --uid ${UID} nginx-host-uid
         pull_policy: never

--- a/loadbalancer/Makefile
+++ b/loadbalancer/Makefile
@@ -66,7 +66,7 @@ include ../deployment/logrotate.make
 
 # Rule to send nginx USR1 signal via docker compose (used by `logrotate.conf`)
 nginx-send-usr1:
-	docker compose exec -T loadbalancer /bin/bash -c 'kill -USR1 `pgrep -f "nginx: [m]aster"`'
+	docker compose kill --signal=SIGUSR1 loadbalancer
 
 # Rule to send nginx HUP signal to reload configuration
 nginx-send-hup:

--- a/loadbalancer/docker-compose.yml
+++ b/loadbalancer/docker-compose.yml
@@ -5,7 +5,7 @@ services:
         build:
           context: .
           dockerfile_inline: |
-            FROM jonasal/nginx-certbot:5.0.1
+            FROM jonasal/nginx-certbot:5.2.0
             RUN groupadd --gid ${GID} nginx-host-uid && \
                 useradd --gid nginx-host-uid --no-create-home --home /nonexistent --comment "nginx user with host uid" --shell /bin/false --uid ${UID} nginx-host-uid
         pull_policy: never


### PR DESCRIPTION
In version [5.2.0] of the nginx-certbot image it is possible to send SIGUSR1 directly to the container instead of going through docker exec + pgrep + kill.

[5.2.0]: https://github.com/JonasAlfredsson/docker-nginx-certbot/blob/master/docs/changelog.md#520