### PR TITLE
Disable watchtower for the nginx-certbot image

### DIFF
--- a/deployment/docker-compose.yml
+++ b/deployment/docker-compose.yml
@@ -61,8 +61,6 @@ services:
             - ./storage/cache:/caches/pkgserver/cache
             - ./storage/static:/caches/pkgserver/static
             - ./storage/s3cache:/caches/s3
-        labels:
-            com.centurylinklabs.watchtower.scope: "pkgserver.jl"
 
     # Auto-reload docker containers when their images are updated
     watchtower:

--- a/loadbalancer/Makefile
+++ b/loadbalancer/Makefile
@@ -72,9 +72,6 @@ nginx-send-usr1:
 nginx-send-hup:
 	docker compose kill --signal=SIGHUP loadbalancer
 
-stop-watchtower:
-	docker compose stop watchtower
-
 logs:
 	docker compose logs -f --tail=100
 .PHONY: logs

--- a/loadbalancer/docker-compose.yml
+++ b/loadbalancer/docker-compose.yml
@@ -23,19 +23,6 @@ services:
             - letsencrypt:/etc/letsencrypt
             # Store logs for us to peruse at our leisure
             - ./logs/nginx:/logs
-        labels:
-            com.centurylinklabs.watchtower.scope: "pkgserver.jl"
-
-    # Auto-reload docker containers when their images are updated
-    watchtower:
-        image: containrrr/watchtower
-        restart: unless-stopped
-        volumes:
-            # Mount the docker socket
-            - /var/run/docker.sock:/var/run/docker.sock
-        command: --cleanup --scope pkgserver.jl
-        labels:
-            com.centurylinklabs.watchtower.scope: "pkgserver.jl"
 
 volumes:
     letsencrypt:


### PR DESCRIPTION
It seems like watchtower chokes on this image now that we manage it ourselves through the `build: ` configuration. The image is rarely updated anyway and we have infrastructure to update it in other ways now.