### PR TITLE
allow passing a `Accept-Encoding` header to PkgServer to fetch e.g. zstd compressed files from the storage server

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,13 +31,13 @@ jobs:
           - 'true'
           - 'false'
     steps:
-      - uses: actions/checkout@v2
-      - uses: julia-actions/setup-julia@v1
+      - uses: actions/checkout@v5
+      - uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.julia-version }}
           arch: ${{ matrix.julia-arch }}
       - name: Cache artifacts
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         env:
           cache-name: cache-artifacts
         with:
@@ -75,7 +75,7 @@ jobs:
     needs: test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v5
       - name: docker login
         run: echo "${DOCKER_PASSWORD}" | docker login --username "${DOCKER_USERNAME}" --password-stdin
         env:

--- a/.github/workflows/pkg-update.yml
+++ b/.github/workflows/pkg-update.yml
@@ -7,8 +7,8 @@ jobs:
   update-manifest:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: julia-actions/setup-julia@v1
+      - uses: actions/checkout@v5
+      - uses: julia-actions/setup-julia@v2
         with:
           # Keep in sync with the ci.yml and the Dockerfile
           version: "1.10"


### PR DESCRIPTION
for backwards compatibility, return gzipped files when no `Accept-Encoding` is provided

Written together with Claude code, but a lot of hand-holding and manual tweaking.